### PR TITLE
Post-review API changes

### DIFF
--- a/muxado/src/codec.rs
+++ b/muxado/src/codec.rs
@@ -215,7 +215,7 @@ mod test {
     #[test]
     fn round_trip() {
         let frame = Frame::from(Body::Data(Bytes::from_static(b"Hello, world!")))
-            .with_stream_id(StreamID::clamp(5));
+            .stream_id(StreamID::clamp(5));
         let mut buf = bytes::BytesMut::new();
         let mut codec = FrameCodec::default();
 

--- a/muxado/src/frame.rs
+++ b/muxado/src/frame.rs
@@ -85,7 +85,7 @@ impl Frame {
         self.header.flags.set(Flags::SYN, true);
         self
     }
-    pub fn with_stream_id(mut self, id: StreamID) -> Frame {
+    pub fn stream_id(mut self, id: StreamID) -> Frame {
         self.header.stream_id = id;
         self
     }

--- a/muxado/src/session.rs
+++ b/muxado/src/session.rs
@@ -72,7 +72,7 @@ where
 
     /// Set the stream window size.
     /// Defaults to 256kb.
-    pub fn with_window_size(mut self, size: usize) -> Self {
+    pub fn window_size(mut self, size: usize) -> Self {
         self.window = size;
         self
     }
@@ -82,7 +82,7 @@ where
     /// from the remote. If [Accept::accept] isn't called and the
     /// channel fills up, the session will block.
     /// Defaults to 64.
-    pub fn with_accept_queue_size(mut self, size: usize) -> Self {
+    pub fn accept_queue_size(mut self, size: usize) -> Self {
         self.accept_queue_size = size;
         self
     }
@@ -90,7 +90,7 @@ where
     /// Set the maximum number of streams allowed at a given time.
     /// If this limit is reached, new streams will be refused.
     /// Defaults to 512.
-    pub fn with_stream_limit(mut self, count: usize) -> Self {
+    pub fn stream_limit(mut self, count: usize) -> Self {
         self.stream_limit = count;
         self
     }

--- a/muxado/src/stream_manager.rs
+++ b/muxado/src/stream_manager.rs
@@ -250,7 +250,7 @@ impl StreamT for StreamManager {
                 return Poll::Pending;
             }
         }
-        .with_stream_id(id);
+        .stream_id(id);
 
         Some(frame).into()
     }

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3.25"
 hyper = { version = "0.14.23", features = ["server"] }
 axum = { version = "0.6.1", features = ["tokio"] }
 rustls-pemfile = "1.0.1"
+async-trait = "0.1.59"
 
 [build-dependencies]
 prost-build = "0.11.3"

--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -6,9 +6,9 @@ use axum::{
     Router,
 };
 use ngrok::{
-    config::HTTPEndpoint,
+    config::TunnelBuilder,
+    HttpTunnel,
     Session,
-    Tunnel,
 };
 
 #[tokio::main]
@@ -36,44 +36,43 @@ async fn main() -> anyhow::Result<()> {
 
 // const CA_CERT: &[u8] = include_bytes!("ca.crt");
 
-async fn start_tunnel() -> anyhow::Result<Tunnel> {
+async fn start_tunnel() -> anyhow::Result<HttpTunnel> {
     let sess = Session::builder()
         .with_authtoken_from_env()
         .connect()
         .await?;
 
     let tun = sess
-        .start_tunnel(
-            HTTPEndpoint::default()
-                // .with_allow_cidr_string("0.0.0.0/0")
-                // .with_basic_auth("ngrok", "online1line")
-                // .with_circuit_breaker(0.5)
-                // .with_compression()
-                // .with_deny_cidr_string("10.1.1.1/32")
-                // .with_domain("<somedomain>.ngrok.io")
-                // .with_mutual_tlsca(CA_CERT.into())
-                // .with_oauth(
-                //     OauthOptions::new("google")
-                //         .with_allow_email("<user>@<domain>")
-                //         .with_allow_domain("<domain>")
-                //         .with_scope("<scope>"),
-                // )
-                // .with_oidc(
-                //     OidcOptions::new("<url>", "<id>", "<secret>")
-                //         .with_allow_email("<user>@<domain>")
-                //         .with_allow_domain("<domain>")
-                //         .with_scope("<scope>"),
-                // )
-                // .with_proxy_proto(ProxyProto::None)
-                // .with_remove_request_header("X-Req-Nope")
-                // .with_remove_response_header("X-Res-Nope")
-                // .with_request_header("X-Req-Yup", "true")
-                // .with_response_header("X-Res-Yup", "true")
-                // .with_scheme(ngrok::Scheme::HTTPS)
-                // .with_websocket_tcp_conversion()
-                // .with_webhook_verification("twilio", "asdf"),
-                .with_metadata("example tunnel metadata from rust"),
-        )
+        .http_endpoint()
+        // .with_allow_cidr_string("0.0.0.0/0")
+        // .with_basic_auth("ngrok", "online1line")
+        // .with_circuit_breaker(0.5)
+        // .with_compression()
+        // .with_deny_cidr_string("10.1.1.1/32")
+        // .with_domain("<somedomain>.ngrok.io")
+        // .with_mutual_tlsca(CA_CERT.into())
+        // .with_oauth(
+        //     OauthOptions::new("google")
+        //         .with_allow_email("<user>@<domain>")
+        //         .with_allow_domain("<domain>")
+        //         .with_scope("<scope>"),
+        // )
+        // .with_oidc(
+        //     OidcOptions::new("<url>", "<id>", "<secret>")
+        //         .with_allow_email("<user>@<domain>")
+        //         .with_allow_domain("<domain>")
+        //         .with_scope("<scope>"),
+        // )
+        // .with_proxy_proto(ProxyProto::None)
+        // .with_remove_request_header("X-Req-Nope")
+        // .with_remove_response_header("X-Res-Nope")
+        // .with_request_header("X-Req-Yup", "true")
+        // .with_response_header("X-Res-Yup", "true")
+        // .with_scheme(ngrok::Scheme::HTTPS)
+        // .with_websocket_tcp_conversion()
+        // .with_webhook_verification("twilio", "asdf"),
+        .with_metadata("example tunnel metadata from rust")
+        .listen()
         .await?;
 
     println!("Tunnel started on URL: {:?}", tun.url());

--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -5,11 +5,7 @@ use axum::{
     routing::get,
     Router,
 };
-use ngrok::{
-    config::TunnelBuilder,
-    HttpTunnel,
-    Session,
-};
+use ngrok::prelude::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -36,8 +32,8 @@ async fn main() -> anyhow::Result<()> {
 
 // const CA_CERT: &[u8] = include_bytes!("ca.crt");
 
-async fn start_tunnel() -> anyhow::Result<HttpTunnel> {
-    let sess = Session::builder()
+async fn start_tunnel() -> anyhow::Result<impl UrlTunnel> {
+    let sess = ngrok::Session::builder()
         .with_authtoken_from_env()
         .connect()
         .await?;

--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -33,41 +33,39 @@ async fn main() -> anyhow::Result<()> {
 // const CA_CERT: &[u8] = include_bytes!("ca.crt");
 
 async fn start_tunnel() -> anyhow::Result<impl UrlTunnel> {
-    let sess = ngrok::Session::builder()
-        .with_authtoken_from_env()
+    let tun = ngrok::Session::builder()
+        .authtoken_from_env()
         .connect()
-        .await?;
-
-    let tun = sess
+        .await?
         .http_endpoint()
-        // .with_allow_cidr_string("0.0.0.0/0")
-        // .with_basic_auth("ngrok", "online1line")
-        // .with_circuit_breaker(0.5)
-        // .with_compression()
-        // .with_deny_cidr_string("10.1.1.1/32")
-        // .with_domain("<somedomain>.ngrok.io")
-        // .with_mutual_tlsca(CA_CERT.into())
-        // .with_oauth(
+        // .allow_cidr_string("0.0.0.0/0")
+        // .basic_auth("ngrok", "online1line")
+        // .circuit_breaker(0.5)
+        // .compression()
+        // .deny_cidr_string("10.1.1.1/32")
+        // .domain("<somedomain>.ngrok.io")
+        // .mutual_tlsca(CA_CERT.into())
+        // .oauth(
         //     OauthOptions::new("google")
-        //         .with_allow_email("<user>@<domain>")
-        //         .with_allow_domain("<domain>")
-        //         .with_scope("<scope>"),
+        //         .allow_email("<user>@<domain>")
+        //         .allow_domain("<domain>")
+        //         .scope("<scope>"),
         // )
-        // .with_oidc(
+        // .oidc(
         //     OidcOptions::new("<url>", "<id>", "<secret>")
-        //         .with_allow_email("<user>@<domain>")
-        //         .with_allow_domain("<domain>")
-        //         .with_scope("<scope>"),
+        //         .allow_email("<user>@<domain>")
+        //         .allow_domain("<domain>")
+        //         .scope("<scope>"),
         // )
-        // .with_proxy_proto(ProxyProto::None)
-        // .with_remove_request_header("X-Req-Nope")
-        // .with_remove_response_header("X-Res-Nope")
-        // .with_request_header("X-Req-Yup", "true")
-        // .with_response_header("X-Res-Yup", "true")
-        // .with_scheme(ngrok::Scheme::HTTPS)
-        // .with_websocket_tcp_conversion()
-        // .with_webhook_verification("twilio", "asdf"),
-        .with_metadata("example tunnel metadata from rust")
+        // .proxy_proto(ProxyProto::None)
+        // .remove_request_header("X-Req-Nope")
+        // .remove_response_header("X-Res-Nope")
+        // .request_header("X-Req-Yup", "true")
+        // .response_header("X-Res-Yup", "true")
+        // .scheme(ngrok::Scheme::HTTPS)
+        // .websocket_tcp_conversion()
+        // .webhook_verification("twilio", "asdf"),
+        .metadata("example tunnel metadata from rust")
         .listen()
         .await?;
 

--- a/ngrok/examples/connect.rs
+++ b/ngrok/examples/connect.rs
@@ -18,19 +18,19 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let sess = ngrok::Session::builder()
-        .with_authtoken_from_env()
-        .with_metadata("Online in One Line")
+        .authtoken_from_env()
+        .metadata("Online in One Line")
         .connect()
         .await?;
 
     let tunnel = sess
         .tcp_endpoint()
-        // .with_allow_cidr_string("0.0.0.0/0")
-        // .with_deny_cidr_string("10.1.1.1/32")
-        // .with_forwards_to("example rust"),
-        // .with_proxy_proto(ProxyProto::None)
-        // .with_remote_addr("<n>.tcp.ngrok.io:<p>")
-        .with_metadata("example tunnel metadata from rust")
+        // .allow_cidr_string("0.0.0.0/0")
+        // .deny_cidr_string("10.1.1.1/32")
+        // .forwards_to("example rust"),
+        // .proxy_proto(ProxyProto::None)
+        // .remote_addr("<n>.tcp.ngrok.io:<p>")
+        .metadata("example tunnel metadata from rust")
         .listen()
         .await?;
 

--- a/ngrok/examples/connect.rs
+++ b/ngrok/examples/connect.rs
@@ -1,11 +1,5 @@
-use std::sync::Arc;
-
 use futures::TryStreamExt;
-use ngrok::{
-    config::TunnelBuilder,
-    Session,
-    TcpTunnel,
-};
+use ngrok::prelude::*;
 use tokio::io::{
     self,
     AsyncBufReadExt,
@@ -23,13 +17,11 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(std::env::var("RUST_LOG").unwrap_or_default())
         .init();
 
-    let sess = Arc::new(
-        Session::builder()
-            .with_authtoken_from_env()
-            .with_metadata("Online in One Line")
-            .connect()
-            .await?,
-    );
+    let sess = ngrok::Session::builder()
+        .with_authtoken_from_env()
+        .with_metadata("Online in One Line")
+        .connect()
+        .await?;
 
     let tunnel = sess
         .tcp_endpoint()
@@ -47,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     futures::future::pending().await
 }
 
-fn handle_tunnel(mut tunnel: TcpTunnel, sess: Arc<Session>) {
+fn handle_tunnel(mut tunnel: impl UrlTunnel, sess: ngrok::Session) {
     info!("bound new tunnel: {}", tunnel.url());
     tokio::spawn(async move {
         loop {

--- a/ngrok/examples/labeled.rs
+++ b/ngrok/examples/labeled.rs
@@ -32,14 +32,14 @@ async fn main() -> anyhow::Result<()> {
 
 async fn start_tunnel() -> anyhow::Result<impl Tunnel> {
     let sess = ngrok::Session::builder()
-        .with_authtoken_from_env()
+        .authtoken_from_env()
         .connect()
         .await?;
 
     let tun = sess
         .labeled_tunnel()
-        .with_label("edge", "edghts_<edge_id>")
-        .with_metadata("example tunnel metadata from rust")
+        .label("edge", "edghts_<edge_id>")
+        .metadata("example tunnel metadata from rust")
         .listen()
         .await?;
 

--- a/ngrok/examples/labeled.rs
+++ b/ngrok/examples/labeled.rs
@@ -5,11 +5,7 @@ use axum::{
     routing::get,
     Router,
 };
-use ngrok::{
-    config::TunnelBuilder,
-    LabeledTunnel,
-    Session,
-};
+use ngrok::prelude::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -34,8 +30,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn start_tunnel() -> anyhow::Result<LabeledTunnel> {
-    let sess = Session::builder()
+async fn start_tunnel() -> anyhow::Result<impl Tunnel> {
+    let sess = ngrok::Session::builder()
         .with_authtoken_from_env()
         .connect()
         .await?;

--- a/ngrok/examples/labeled.rs
+++ b/ngrok/examples/labeled.rs
@@ -6,9 +6,9 @@ use axum::{
     Router,
 };
 use ngrok::{
-    config::LabeledTunnel,
+    config::TunnelBuilder,
+    LabeledTunnel,
     Session,
-    Tunnel,
 };
 
 #[tokio::main]
@@ -34,21 +34,20 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn start_tunnel() -> anyhow::Result<Tunnel> {
+async fn start_tunnel() -> anyhow::Result<LabeledTunnel> {
     let sess = Session::builder()
         .with_authtoken_from_env()
         .connect()
         .await?;
 
     let tun = sess
-        .start_tunnel(
-            LabeledTunnel::default()
-                .with_label("edge", "edghts_<edge_id>")
-                .with_metadata("example tunnel metadata from rust"),
-        )
+        .labeled_tunnel()
+        .with_label("edge", "edghts_<edge_id>")
+        .with_metadata("example tunnel metadata from rust")
+        .listen()
         .await?;
 
-    println!("Tunnel started on URL: {:?}", tun.url());
+    println!("Labeled tunnel started!");
 
     Ok(tun)
 }

--- a/ngrok/examples/tls.rs
+++ b/ngrok/examples/tls.rs
@@ -5,11 +5,7 @@ use axum::{
     routing::get,
     Router,
 };
-use ngrok::{
-    config::TunnelBuilder,
-    Session,
-    TlsTunnel,
-};
+use ngrok::prelude::*;
 
 const CERT: &[u8] = include_bytes!("domain.crt");
 const KEY: &[u8] = include_bytes!("domain.key");
@@ -38,8 +34,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn start_tunnel() -> anyhow::Result<TlsTunnel> {
-    let sess = Session::builder()
+async fn start_tunnel() -> anyhow::Result<impl Tunnel> {
+    let sess = ngrok::Session::builder()
         .with_authtoken_from_env()
         .connect()
         .await?;

--- a/ngrok/examples/tls.rs
+++ b/ngrok/examples/tls.rs
@@ -6,9 +6,9 @@ use axum::{
     Router,
 };
 use ngrok::{
-    config::TLSEndpoint,
+    config::TunnelBuilder,
     Session,
-    Tunnel,
+    TlsTunnel,
 };
 
 const CERT: &[u8] = include_bytes!("domain.crt");
@@ -38,25 +38,24 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn start_tunnel() -> anyhow::Result<Tunnel> {
+async fn start_tunnel() -> anyhow::Result<TlsTunnel> {
     let sess = Session::builder()
         .with_authtoken_from_env()
         .connect()
         .await?;
 
     let tun = sess
-        .start_tunnel(
-            TLSEndpoint::default()
-                // .with_allow_cidr_string("0.0.0.0/0")
-                // .with_deny_cidr_string("10.1.1.1/32")
-                // .with_domain("<somedomain>.ngrok.io")
-                // .with_forwards_to("example rust"),
-                // .with_mutual_tlsca(CA_CERT.into())
-                // .with_proxy_proto(ProxyProto::None)
-                .with_cert_pem(CERT.into())
-                .with_key_pem(KEY.into())
-                .with_metadata("example tunnel metadata from rust"),
-        )
+        .tls_endpoint()
+        // .with_allow_cidr_string("0.0.0.0/0")
+        // .with_deny_cidr_string("10.1.1.1/32")
+        // .with_domain("<somedomain>.ngrok.io")
+        // .with_forwards_to("example rust"),
+        // .with_mutual_tlsca(CA_CERT.into())
+        // .with_proxy_proto(ProxyProto::None)
+        .with_cert_pem(CERT.into())
+        .with_key_pem(KEY.into())
+        .with_metadata("example tunnel metadata from rust")
+        .listen()
         .await?;
 
     println!("Tunnel started on URL: {:?}", tun.url());

--- a/ngrok/examples/tls.rs
+++ b/ngrok/examples/tls.rs
@@ -36,21 +36,21 @@ async fn main() -> anyhow::Result<()> {
 
 async fn start_tunnel() -> anyhow::Result<impl Tunnel> {
     let sess = ngrok::Session::builder()
-        .with_authtoken_from_env()
+        .authtoken_from_env()
         .connect()
         .await?;
 
     let tun = sess
         .tls_endpoint()
-        // .with_allow_cidr_string("0.0.0.0/0")
-        // .with_deny_cidr_string("10.1.1.1/32")
-        // .with_domain("<somedomain>.ngrok.io")
-        // .with_forwards_to("example rust"),
-        // .with_mutual_tlsca(CA_CERT.into())
-        // .with_proxy_proto(ProxyProto::None)
-        .with_cert_pem(CERT.into())
-        .with_key_pem(KEY.into())
-        .with_metadata("example tunnel metadata from rust")
+        // .allow_cidr_string("0.0.0.0/0")
+        // .deny_cidr_string("10.1.1.1/32")
+        // .domain("<somedomain>.ngrok.io")
+        // .forwards_to("example rust"),
+        // .mutual_tlsca(CA_CERT.into())
+        // .proxy_proto(ProxyProto::None)
+        .cert_pem(CERT.into())
+        .key_pem(KEY.into())
+        .metadata("example tunnel metadata from rust")
         .listen()
         .await?;
 

--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -108,7 +108,7 @@ where
 
 /// Restrictions placed on the origin of incoming connections to the edge.
 #[derive(Clone, Default)]
-pub struct CidrRestrictions {
+pub(crate) struct CidrRestrictions {
     /// Rejects connections that do not match the given CIDRs
     pub(crate) allowed: Vec<String>,
     /// Rejects connections that match the given CIDRs and allows all other CIDRs.

--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -13,7 +13,9 @@ use crate::{
         BindExtra,
         BindOpts,
     },
+    session::RpcError,
     Session,
+    Tunnel,
 };
 
 pub(crate) const FORWARDS_TO: &str = "rust";
@@ -22,12 +24,10 @@ pub(crate) const FORWARDS_TO: &str = "rust";
 #[async_trait]
 pub trait TunnelBuilder: From<Session> {
     /// The ngrok tunnel type that this builder produces.
-    type Tunnel;
-    /// The type of error that may arise when listening on this tunnel.
-    type Error;
+    type Tunnel: Tunnel;
 
     /// Begin listening for new connections on this tunnel.
-    async fn listen(&self) -> Result<Self::Tunnel, Self::Error>;
+    async fn listen(&self) -> Result<Self::Tunnel, RpcError>;
 }
 
 macro_rules! impl_builder {
@@ -52,7 +52,6 @@ macro_rules! impl_builder {
         #[async_trait]
         impl TunnelBuilder for $name {
             type Tunnel = $tun;
-            type Error = RpcError;
 
             async fn listen(&self) -> Result<$tun, RpcError> {
                 Ok($tun {

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -162,90 +162,90 @@ impl_builder! {
 impl HttpTunnelBuilder {
     /// Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_allow_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
+    pub fn with_allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_deny_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
+    pub fn with_deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// The version of PROXY protocol to use with this tunnel, None if not using.
-    pub fn with_proxy_proto(&mut self, proxy_proto: ProxyProto) -> &mut Self {
+    pub fn with_proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Tunnel-specific opaque metadata. Viewable via the API.
-    pub fn with_metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
+    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Tunnel backend metadata. Viewable via the dashboard and API, but has no
     /// bearing on tunnel behavior.
-    pub fn with_forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
+    pub fn with_forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// The scheme that this edge should use.
     /// Defaults to [Scheme::HTTPS].
-    pub fn with_scheme(&mut self, scheme: Scheme) -> &mut Self {
+    pub fn with_scheme(mut self, scheme: Scheme) -> Self {
         self.options.scheme = scheme;
         self
     }
     /// The domain to request for this edge.
-    pub fn with_domain(&mut self, domain: impl Into<String>) -> &mut Self {
+    pub fn with_domain(mut self, domain: impl Into<String>) -> Self {
         self.options.domain = Some(domain.into());
         self
     }
     /// Certificates to use for client authentication at the ngrok edge.
-    pub fn with_mutual_tlsca(&mut self, mutual_tlsca: Bytes) -> &mut Self {
+    pub fn with_mutual_tlsca(mut self, mutual_tlsca: Bytes) -> Self {
         self.options.mutual_tlsca.push(mutual_tlsca);
         self
     }
     /// Enable gzip compression for HTTP responses.
-    pub fn with_compression(&mut self) -> &mut Self {
+    pub fn with_compression(mut self) -> Self {
         self.options.compression = true;
         self
     }
     /// Convert incoming websocket connections to TCP-like streams.
-    pub fn with_websocket_tcp_conversion(&mut self) -> &mut Self {
+    pub fn with_websocket_tcp_conversion(mut self) -> Self {
         self.options.websocket_tcp_conversion = true;
         self
     }
     /// Reject requests when 5XX responses exceed this ratio.
     /// Disabled when 0.
-    pub fn with_circuit_breaker(&mut self, circuit_breaker: f64) -> &mut Self {
+    pub fn with_circuit_breaker(mut self, circuit_breaker: f64) -> Self {
         self.options.circuit_breaker = circuit_breaker;
         self
     }
 
     /// with_request_header adds a header to all requests to this edge.
     pub fn with_request_header(
-        &mut self,
+        mut self,
         name: impl Into<String>,
         value: impl Into<String>,
-    ) -> &mut Self {
+    ) -> Self {
         self.options.request_headers.add(name, value);
         self
     }
     /// with_response_header adds a header to all responses coming from this edge.
     pub fn with_response_header(
-        &mut self,
+        mut self,
         name: impl Into<String>,
         value: impl Into<String>,
-    ) -> &mut Self {
+    ) -> Self {
         self.options.response_headers.add(name, value);
         self
     }
     /// with_remove_request_header removes a header from requests to this edge.
-    pub fn with_remove_request_header(&mut self, name: impl Into<String>) -> &mut Self {
+    pub fn with_remove_request_header(mut self, name: impl Into<String>) -> Self {
         self.options.request_headers.remove(name);
         self
     }
     /// with_remove_response_header removes a header from responses from this edge.
-    pub fn with_remove_response_header(&mut self, name: impl Into<String>) -> &mut Self {
+    pub fn with_remove_response_header(mut self, name: impl Into<String>) -> Self {
         self.options.response_headers.remove(name);
         self
     }
@@ -253,10 +253,10 @@ impl HttpTunnelBuilder {
     /// Credentials for basic authentication.
     /// If not called, basic authentication is disabled.
     pub fn with_basic_auth(
-        &mut self,
+        mut self,
         username: impl Into<String>,
         password: impl Into<String>,
-    ) -> &mut Self {
+    ) -> Self {
         self.options
             .basic_auth
             .push((username.into(), password.into()));
@@ -265,14 +265,14 @@ impl HttpTunnelBuilder {
 
     /// OAuth configuration.
     /// If not called, OAuth is disabled.
-    pub fn with_oauth(&mut self, oauth: OauthOptions) -> &mut Self {
+    pub fn with_oauth(mut self, oauth: OauthOptions) -> Self {
         self.options.oauth = Some(oauth);
         self
     }
 
     /// OIDC configuration.
     /// If not called, OIDC is disabled.
-    pub fn with_oidc(&mut self, oidc: OidcOptions) -> &mut Self {
+    pub fn with_oidc(mut self, oidc: OidcOptions) -> Self {
         self.options.oidc = Some(oidc);
         self
     }
@@ -280,10 +280,10 @@ impl HttpTunnelBuilder {
     /// WebhookVerification configuration.
     /// If not called, WebhookVerification is disabled.
     pub fn with_webhook_verification(
-        &mut self,
+        mut self,
         provider: impl Into<String>,
         secret: impl Into<String>,
-    ) -> &mut Self {
+    ) -> Self {
         self.options.webhook_verification = Some(WebhookVerification {
             provider: provider.into(),
             secret: secret.into(),

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
 
+use async_trait::async_trait;
 use prost::bytes::{
     self,
     Bytes,
 };
 
-use super::common::ProxyProto;
+use super::{
+    common::ProxyProto,
+    TunnelBuilder,
+};
 use crate::{
     config::{
         common::{
@@ -33,6 +37,9 @@ use crate::{
         BindExtra,
         BindOpts,
     },
+    HttpTunnel,
+    RpcError,
+    Session,
 };
 
 /// The URL scheme for this HTTP endpoint.
@@ -48,8 +55,8 @@ pub enum Scheme {
 }
 
 /// The options for a HTTP edge.
-#[derive(Default)]
-pub struct HTTPEndpoint {
+#[derive(Default, Clone)]
+struct HttpOptions {
     pub(crate) common_opts: CommonOpts,
     pub(crate) scheme: Scheme,
     pub(crate) domain: Option<String>,
@@ -65,7 +72,7 @@ pub struct HTTPEndpoint {
     pub(crate) webhook_verification: Option<WebhookVerification>,
 }
 
-impl TunnelConfig for HTTPEndpoint {
+impl TunnelConfig for HttpOptions {
     fn forwards_to(&self) -> String {
         self.common_opts
             .forwards_to
@@ -147,65 +154,70 @@ impl From<(String, String)> for BasicAuthCredential {
     }
 }
 
-impl HTTPEndpoint {
+impl_builder! {
+    /// A builder for a tunnel backing an HTTP endpoint.
+    HttpTunnelBuilder, HttpOptions, HttpTunnel
+}
+
+impl HttpTunnelBuilder {
     /// Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
     pub fn with_allow_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
-        self.common_opts.cidr_restrictions.allow(cidr);
+        self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
     pub fn with_deny_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
-        self.common_opts.cidr_restrictions.deny(cidr);
+        self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// The version of PROXY protocol to use with this tunnel, None if not using.
     pub fn with_proxy_proto(&mut self, proxy_proto: ProxyProto) -> &mut Self {
-        self.common_opts.proxy_proto = proxy_proto;
+        self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Tunnel-specific opaque metadata. Viewable via the API.
     pub fn with_metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
-        self.common_opts.metadata = Some(metadata.into());
+        self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Tunnel backend metadata. Viewable via the dashboard and API, but has no
     /// bearing on tunnel behavior.
     pub fn with_forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
-        self.common_opts.forwards_to = Some(forwards_to.into());
+        self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// The scheme that this edge should use.
-    /// Defaults to [HTTPS].
+    /// Defaults to [Scheme::HTTPS].
     pub fn with_scheme(&mut self, scheme: Scheme) -> &mut Self {
-        self.scheme = scheme;
+        self.options.scheme = scheme;
         self
     }
-    /// The domain to request for this edge
+    /// The domain to request for this edge.
     pub fn with_domain(&mut self, domain: impl Into<String>) -> &mut Self {
-        self.domain = Some(domain.into());
+        self.options.domain = Some(domain.into());
         self
     }
     /// Certificates to use for client authentication at the ngrok edge.
     pub fn with_mutual_tlsca(&mut self, mutual_tlsca: Bytes) -> &mut Self {
-        self.mutual_tlsca.push(mutual_tlsca);
+        self.options.mutual_tlsca.push(mutual_tlsca);
         self
     }
     /// Enable gzip compression for HTTP responses.
     pub fn with_compression(&mut self) -> &mut Self {
-        self.compression = true;
+        self.options.compression = true;
         self
     }
     /// Convert incoming websocket connections to TCP-like streams.
     pub fn with_websocket_tcp_conversion(&mut self) -> &mut Self {
-        self.websocket_tcp_conversion = true;
+        self.options.websocket_tcp_conversion = true;
         self
     }
     /// Reject requests when 5XX responses exceed this ratio.
     /// Disabled when 0.
     pub fn with_circuit_breaker(&mut self, circuit_breaker: f64) -> &mut Self {
-        self.circuit_breaker = circuit_breaker;
+        self.options.circuit_breaker = circuit_breaker;
         self
     }
 
@@ -215,7 +227,7 @@ impl HTTPEndpoint {
         name: impl Into<String>,
         value: impl Into<String>,
     ) -> &mut Self {
-        self.request_headers.add(name, value);
+        self.options.request_headers.add(name, value);
         self
     }
     /// with_response_header adds a header to all responses coming from this edge.
@@ -224,17 +236,17 @@ impl HTTPEndpoint {
         name: impl Into<String>,
         value: impl Into<String>,
     ) -> &mut Self {
-        self.response_headers.add(name, value);
+        self.options.response_headers.add(name, value);
         self
     }
     /// with_remove_request_header removes a header from requests to this edge.
     pub fn with_remove_request_header(&mut self, name: impl Into<String>) -> &mut Self {
-        self.request_headers.remove(name);
+        self.options.request_headers.remove(name);
         self
     }
     /// with_remove_response_header removes a header from responses from this edge.
     pub fn with_remove_response_header(&mut self, name: impl Into<String>) -> &mut Self {
-        self.response_headers.remove(name);
+        self.options.response_headers.remove(name);
         self
     }
 
@@ -245,21 +257,23 @@ impl HTTPEndpoint {
         username: impl Into<String>,
         password: impl Into<String>,
     ) -> &mut Self {
-        self.basic_auth.push((username.into(), password.into()));
+        self.options
+            .basic_auth
+            .push((username.into(), password.into()));
         self
     }
 
     /// OAuth configuration.
     /// If not called, OAuth is disabled.
     pub fn with_oauth(&mut self, oauth: OauthOptions) -> &mut Self {
-        self.oauth = Some(oauth);
+        self.options.oauth = Some(oauth);
         self
     }
 
     /// OIDC configuration.
     /// If not called, OIDC is disabled.
     pub fn with_oidc(&mut self, oidc: OidcOptions) -> &mut Self {
-        self.oidc = Some(oidc);
+        self.options.oidc = Some(oidc);
         self
     }
 
@@ -270,7 +284,7 @@ impl HTTPEndpoint {
         provider: impl Into<String>,
         secret: impl Into<String>,
     ) -> &mut Self {
-        self.webhook_verification = Some(WebhookVerification {
+        self.options.webhook_verification = Some(WebhookVerification {
             provider: provider.into(),
             secret: secret.into(),
         });
@@ -295,39 +309,43 @@ mod test {
         // pass to a function accepting the trait to avoid
         // "creates a temporary which is freed while still in use"
         tunnel_test(
-            HTTPEndpoint::default()
-                .with_allow_cidr_string(ALLOW_CIDR)
-                .with_deny_cidr_string(DENY_CIDR)
-                .with_proxy_proto(ProxyProto::V2)
-                .with_metadata(METADATA)
-                .with_scheme(Scheme::HTTPS)
-                .with_domain(DOMAIN)
-                .with_mutual_tlsca(CA_CERT.into())
-                .with_mutual_tlsca(CA_CERT2.into())
-                .with_compression()
-                .with_websocket_tcp_conversion()
-                .with_circuit_breaker(0.5)
-                .with_request_header("X-Req-Yup", "true")
-                .with_response_header("X-Res-Yup", "true")
-                .with_remove_request_header("X-Req-Nope")
-                .with_remove_response_header("X-Res-Nope")
-                .with_oauth(OauthOptions::new("google"))
-                .with_oauth(
-                    OauthOptions::new("google")
-                        .with_allow_email("<user>@<domain>")
-                        .with_allow_domain("<domain>")
-                        .with_scope("<scope>"),
-                )
-                .with_oidc(OidcOptions::new("<url>", "<id>", "<secret>"))
-                .with_oidc(
-                    OidcOptions::new("<url>", "<id>", "<secret>")
-                        .with_allow_email("<user>@<domain>")
-                        .with_allow_domain("<domain>")
-                        .with_scope("<scope>"),
-                )
-                .with_webhook_verification("twilio", "asdf")
-                .with_basic_auth("ngrok", "online1line")
-                .with_forwards_to(TEST_FORWARD),
+            &HttpTunnelBuilder {
+                session: None,
+                options: Default::default(),
+            }
+            .with_allow_cidr_string(ALLOW_CIDR)
+            .with_deny_cidr_string(DENY_CIDR)
+            .with_proxy_proto(ProxyProto::V2)
+            .with_metadata(METADATA)
+            .with_scheme(Scheme::HTTPS)
+            .with_domain(DOMAIN)
+            .with_mutual_tlsca(CA_CERT.into())
+            .with_mutual_tlsca(CA_CERT2.into())
+            .with_compression()
+            .with_websocket_tcp_conversion()
+            .with_circuit_breaker(0.5)
+            .with_request_header("X-Req-Yup", "true")
+            .with_response_header("X-Res-Yup", "true")
+            .with_remove_request_header("X-Req-Nope")
+            .with_remove_response_header("X-Res-Nope")
+            .with_oauth(OauthOptions::new("google"))
+            .with_oauth(
+                OauthOptions::new("google")
+                    .with_allow_email("<user>@<domain>")
+                    .with_allow_domain("<domain>")
+                    .with_scope("<scope>"),
+            )
+            .with_oidc(OidcOptions::new("<url>", "<id>", "<secret>"))
+            .with_oidc(
+                OidcOptions::new("<url>", "<id>", "<secret>")
+                    .with_allow_email("<user>@<domain>")
+                    .with_allow_domain("<domain>")
+                    .with_scope("<scope>"),
+            )
+            .with_webhook_verification("twilio", "asdf")
+            .with_basic_auth("ngrok", "online1line")
+            .with_forwards_to(TEST_FORWARD)
+            .options,
         );
     }
 

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -162,101 +162,89 @@ impl_builder! {
 impl HttpTunnelBuilder {
     /// Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
+    pub fn allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
+    pub fn deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// The version of PROXY protocol to use with this tunnel, None if not using.
-    pub fn with_proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
+    pub fn proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Tunnel-specific opaque metadata. Viewable via the API.
-    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Tunnel backend metadata. Viewable via the dashboard and API, but has no
     /// bearing on tunnel behavior.
-    pub fn with_forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
+    pub fn forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// The scheme that this edge should use.
     /// Defaults to [Scheme::HTTPS].
-    pub fn with_scheme(mut self, scheme: Scheme) -> Self {
+    pub fn scheme(mut self, scheme: Scheme) -> Self {
         self.options.scheme = scheme;
         self
     }
     /// The domain to request for this edge.
-    pub fn with_domain(mut self, domain: impl Into<String>) -> Self {
+    pub fn domain(mut self, domain: impl Into<String>) -> Self {
         self.options.domain = Some(domain.into());
         self
     }
     /// Certificates to use for client authentication at the ngrok edge.
-    pub fn with_mutual_tlsca(mut self, mutual_tlsca: Bytes) -> Self {
+    pub fn mutual_tlsca(mut self, mutual_tlsca: Bytes) -> Self {
         self.options.mutual_tlsca.push(mutual_tlsca);
         self
     }
     /// Enable gzip compression for HTTP responses.
-    pub fn with_compression(mut self) -> Self {
+    pub fn compression(mut self) -> Self {
         self.options.compression = true;
         self
     }
     /// Convert incoming websocket connections to TCP-like streams.
-    pub fn with_websocket_tcp_conversion(mut self) -> Self {
+    pub fn websocket_tcp_conversion(mut self) -> Self {
         self.options.websocket_tcp_conversion = true;
         self
     }
     /// Reject requests when 5XX responses exceed this ratio.
     /// Disabled when 0.
-    pub fn with_circuit_breaker(mut self, circuit_breaker: f64) -> Self {
+    pub fn circuit_breaker(mut self, circuit_breaker: f64) -> Self {
         self.options.circuit_breaker = circuit_breaker;
         self
     }
 
     /// with_request_header adds a header to all requests to this edge.
-    pub fn with_request_header(
-        mut self,
-        name: impl Into<String>,
-        value: impl Into<String>,
-    ) -> Self {
+    pub fn request_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.options.request_headers.add(name, value);
         self
     }
     /// with_response_header adds a header to all responses coming from this edge.
-    pub fn with_response_header(
-        mut self,
-        name: impl Into<String>,
-        value: impl Into<String>,
-    ) -> Self {
+    pub fn response_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.options.response_headers.add(name, value);
         self
     }
     /// with_remove_request_header removes a header from requests to this edge.
-    pub fn with_remove_request_header(mut self, name: impl Into<String>) -> Self {
+    pub fn remove_request_header(mut self, name: impl Into<String>) -> Self {
         self.options.request_headers.remove(name);
         self
     }
     /// with_remove_response_header removes a header from responses from this edge.
-    pub fn with_remove_response_header(mut self, name: impl Into<String>) -> Self {
+    pub fn remove_response_header(mut self, name: impl Into<String>) -> Self {
         self.options.response_headers.remove(name);
         self
     }
 
     /// Credentials for basic authentication.
     /// If not called, basic authentication is disabled.
-    pub fn with_basic_auth(
-        mut self,
-        username: impl Into<String>,
-        password: impl Into<String>,
-    ) -> Self {
+    pub fn basic_auth(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
         self.options
             .basic_auth
             .push((username.into(), password.into()));
@@ -265,21 +253,21 @@ impl HttpTunnelBuilder {
 
     /// OAuth configuration.
     /// If not called, OAuth is disabled.
-    pub fn with_oauth(mut self, oauth: OauthOptions) -> Self {
+    pub fn oauth(mut self, oauth: OauthOptions) -> Self {
         self.options.oauth = Some(oauth);
         self
     }
 
     /// OIDC configuration.
     /// If not called, OIDC is disabled.
-    pub fn with_oidc(mut self, oidc: OidcOptions) -> Self {
+    pub fn oidc(mut self, oidc: OidcOptions) -> Self {
         self.options.oidc = Some(oidc);
         self
     }
 
     /// WebhookVerification configuration.
     /// If not called, WebhookVerification is disabled.
-    pub fn with_webhook_verification(
+    pub fn webhook_verification(
         mut self,
         provider: impl Into<String>,
         secret: impl Into<String>,
@@ -313,38 +301,38 @@ mod test {
                 session: None,
                 options: Default::default(),
             }
-            .with_allow_cidr_string(ALLOW_CIDR)
-            .with_deny_cidr_string(DENY_CIDR)
-            .with_proxy_proto(ProxyProto::V2)
-            .with_metadata(METADATA)
-            .with_scheme(Scheme::HTTPS)
-            .with_domain(DOMAIN)
-            .with_mutual_tlsca(CA_CERT.into())
-            .with_mutual_tlsca(CA_CERT2.into())
-            .with_compression()
-            .with_websocket_tcp_conversion()
-            .with_circuit_breaker(0.5)
-            .with_request_header("X-Req-Yup", "true")
-            .with_response_header("X-Res-Yup", "true")
-            .with_remove_request_header("X-Req-Nope")
-            .with_remove_response_header("X-Res-Nope")
-            .with_oauth(OauthOptions::new("google"))
-            .with_oauth(
+            .allow_cidr_string(ALLOW_CIDR)
+            .deny_cidr_string(DENY_CIDR)
+            .proxy_proto(ProxyProto::V2)
+            .metadata(METADATA)
+            .scheme(Scheme::HTTPS)
+            .domain(DOMAIN)
+            .mutual_tlsca(CA_CERT.into())
+            .mutual_tlsca(CA_CERT2.into())
+            .compression()
+            .websocket_tcp_conversion()
+            .circuit_breaker(0.5)
+            .request_header("X-Req-Yup", "true")
+            .response_header("X-Res-Yup", "true")
+            .remove_request_header("X-Req-Nope")
+            .remove_response_header("X-Res-Nope")
+            .oauth(OauthOptions::new("google"))
+            .oauth(
                 OauthOptions::new("google")
-                    .with_allow_email("<user>@<domain>")
-                    .with_allow_domain("<domain>")
-                    .with_scope("<scope>"),
+                    .allow_email("<user>@<domain>")
+                    .allow_domain("<domain>")
+                    .scope("<scope>"),
             )
-            .with_oidc(OidcOptions::new("<url>", "<id>", "<secret>"))
-            .with_oidc(
+            .oidc(OidcOptions::new("<url>", "<id>", "<secret>"))
+            .oidc(
                 OidcOptions::new("<url>", "<id>", "<secret>")
-                    .with_allow_email("<user>@<domain>")
-                    .with_allow_domain("<domain>")
-                    .with_scope("<scope>"),
+                    .allow_email("<user>@<domain>")
+                    .allow_domain("<domain>")
+                    .scope("<scope>"),
             )
-            .with_webhook_verification("twilio", "asdf")
-            .with_basic_auth("ngrok", "online1line")
-            .with_forwards_to(TEST_FORWARD)
+            .webhook_verification("twilio", "asdf")
+            .basic_auth("ngrok", "online1line")
+            .forwards_to(TEST_FORWARD)
             .options,
         );
     }

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -37,8 +37,8 @@ use crate::{
         BindExtra,
         BindOpts,
     },
-    HttpTunnel,
-    RpcError,
+    session::RpcError,
+    tunnel::HttpTunnel,
     Session,
 };
 

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -57,13 +57,13 @@ impl_builder! {
 
 impl LabeledTunnelBuilder {
     /// Tunnel-specific opaque metadata. Viewable via the API.
-    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
 
     /// Add a label, value pair for this tunnel.
-    pub fn with_label(mut self, label: impl Into<String>, value: impl Into<String>) -> Self {
+    pub fn label(mut self, label: impl Into<String>, value: impl Into<String>) -> Self {
         self.options.labels.insert(label.into(), value.into());
         self
     }
@@ -86,8 +86,8 @@ mod test {
                 session: None,
                 options: Default::default(),
             }
-            .with_metadata(METADATA)
-            .with_label(LABEL_KEY, LABEL_VAL)
+            .metadata(METADATA)
+            .label(LABEL_KEY, LABEL_VAL)
             .options,
         );
     }

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -57,13 +57,13 @@ impl_builder! {
 
 impl LabeledTunnelBuilder {
     /// Tunnel-specific opaque metadata. Viewable via the API.
-    pub fn with_metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
+    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
 
     /// Add a label, value pair for this tunnel.
-    pub fn with_label(&mut self, label: impl Into<String>, value: impl Into<String>) -> &mut Self {
+    pub fn with_label(mut self, label: impl Into<String>, value: impl Into<String>) -> Self {
         self.options.labels.insert(label.into(), value.into());
         self
     }
@@ -82,7 +82,7 @@ mod test {
         // pass to a function accepting the trait to avoid
         // "creates a temporary which is freed while still in use"
         tunnel_test(
-            &LabeledTunnelBuilder {
+            LabeledTunnelBuilder {
                 session: None,
                 options: Default::default(),
             }

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -13,8 +13,8 @@ use crate::{
         BindExtra,
         BindOpts,
     },
-    LabeledTunnel,
-    RpcError,
+    session::RpcError,
+    tunnel::LabeledTunnel,
     Session,
 };
 

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+use async_trait::async_trait;
+
+use super::TunnelBuilder;
 use crate::{
     config::common::{
         CommonOpts,
@@ -10,16 +13,19 @@ use crate::{
         BindExtra,
         BindOpts,
     },
+    LabeledTunnel,
+    RpcError,
+    Session,
 };
 
 /// Options for labeled tunnels.
-#[derive(Default)]
-pub struct LabeledTunnel {
+#[derive(Default, Clone)]
+struct LabeledOptions {
     pub(crate) common_opts: CommonOpts,
     pub(crate) labels: HashMap<String, String>,
 }
 
-impl TunnelConfig for LabeledTunnel {
+impl TunnelConfig for LabeledOptions {
     fn forwards_to(&self) -> String {
         self.common_opts
             .forwards_to
@@ -44,17 +50,21 @@ impl TunnelConfig for LabeledTunnel {
     }
 }
 
-/// Options for labeled tunnels.
-impl LabeledTunnel {
+impl_builder! {
+    /// A builder for a labeled tunnel.
+    LabeledTunnelBuilder, LabeledOptions, LabeledTunnel
+}
+
+impl LabeledTunnelBuilder {
     /// Tunnel-specific opaque metadata. Viewable via the API.
     pub fn with_metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
-        self.common_opts.metadata = Some(metadata.into());
+        self.options.common_opts.metadata = Some(metadata.into());
         self
     }
 
     /// Add a label, value pair for this tunnel.
     pub fn with_label(&mut self, label: impl Into<String>, value: impl Into<String>) -> &mut Self {
-        self.labels.insert(label.into(), value.into());
+        self.options.labels.insert(label.into(), value.into());
         self
     }
 }
@@ -72,9 +82,13 @@ mod test {
         // pass to a function accepting the trait to avoid
         // "creates a temporary which is freed while still in use"
         tunnel_test(
-            LabeledTunnel::default()
-                .with_metadata(METADATA)
-                .with_label(LABEL_KEY, LABEL_VAL),
+            &LabeledTunnelBuilder {
+                session: None,
+                options: Default::default(),
+            }
+            .with_metadata(METADATA)
+            .with_label(LABEL_KEY, LABEL_VAL)
+            .options,
         );
     }
 

--- a/ngrok/src/config/oauth.rs
+++ b/ngrok/src/config/oauth.rs
@@ -23,17 +23,17 @@ impl OauthOptions {
     }
 
     /// Allow the oauth user with the given email to access the tunnel.
-    pub fn with_allow_email(mut self, email: impl Into<String>) -> Self {
+    pub fn allow_email(mut self, email: impl Into<String>) -> Self {
         self.allow_emails.push(email.into());
         self
     }
     /// Allow the oauth user with the given email domain to access the tunnel.
-    pub fn with_allow_domain(mut self, domain: impl Into<String>) -> Self {
+    pub fn allow_domain(mut self, domain: impl Into<String>) -> Self {
         self.allow_domains.push(domain.into());
         self
     }
     /// Request the given scope from the oauth provider.
-    pub fn with_scope(mut self, scope: impl Into<String>) -> Self {
+    pub fn scope(mut self, scope: impl Into<String>) -> Self {
         self.scopes.push(scope.into());
         self
     }

--- a/ngrok/src/config/oidc.rs
+++ b/ngrok/src/config/oidc.rs
@@ -27,17 +27,17 @@ impl OidcOptions {
     }
 
     /// Allow the oidc user with the given email to access the tunnel.
-    pub fn with_allow_email(mut self, email: impl Into<String>) -> Self {
+    pub fn allow_email(mut self, email: impl Into<String>) -> Self {
         self.allow_emails.push(email.into());
         self
     }
     /// Allow the oidc user with the given email domain to access the tunnel.
-    pub fn with_allow_domain(mut self, domain: impl Into<String>) -> Self {
+    pub fn allow_domain(mut self, domain: impl Into<String>) -> Self {
         self.allow_domains.push(domain.into());
         self
     }
     /// Request the given scope from the oidc provider.
-    pub fn with_scope(mut self, scope: impl Into<String>) -> Self {
+    pub fn scope(mut self, scope: impl Into<String>) -> Self {
         self.scopes.push(scope.into());
         self
     }

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -18,9 +18,9 @@ use crate::{
         BindExtra,
         BindOpts,
     },
-    RpcError,
+    session::RpcError,
+    tunnel::TcpTunnel,
     Session,
-    TcpTunnel,
 };
 
 /// The options for a TCP edge.

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -76,34 +76,34 @@ impl_builder! {
 impl TcpTunnelBuilder {
     /// Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
+    pub fn allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
+    pub fn deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// The version of PROXY protocol to use with this tunnel, None if not using.
-    pub fn with_proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
+    pub fn proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Tunnel-specific opaque metadata. Viewable via the API.
-    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Tunnel backend metadata. Viewable via the dashboard and API, but has no
     /// bearing on tunnel behavior.
-    pub fn with_forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
+    pub fn forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// The TCP address to request for this edge.
-    pub fn with_remote_addr(mut self, remote_addr: impl Into<String>) -> Self {
+    pub fn remote_addr(mut self, remote_addr: impl Into<String>) -> Self {
         self.options.remote_addr = Some(remote_addr.into());
         self
     }
@@ -128,12 +128,12 @@ mod test {
                 session: None,
                 options: Default::default(),
             }
-            .with_allow_cidr_string(ALLOW_CIDR)
-            .with_deny_cidr_string(DENY_CIDR)
-            .with_proxy_proto(ProxyProto::V2)
-            .with_metadata(METADATA)
-            .with_remote_addr(REMOTE_ADDR)
-            .with_forwards_to(TEST_FORWARD)
+            .allow_cidr_string(ALLOW_CIDR)
+            .deny_cidr_string(DENY_CIDR)
+            .proxy_proto(ProxyProto::V2)
+            .metadata(METADATA)
+            .remote_addr(REMOTE_ADDR)
+            .forwards_to(TEST_FORWARD)
             .options,
         );
     }

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -76,34 +76,34 @@ impl_builder! {
 impl TcpTunnelBuilder {
     /// Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_allow_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
+    pub fn with_allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_deny_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
+    pub fn with_deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// The version of PROXY protocol to use with this tunnel, None if not using.
-    pub fn with_proxy_proto(&mut self, proxy_proto: ProxyProto) -> &mut Self {
+    pub fn with_proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Tunnel-specific opaque metadata. Viewable via the API.
-    pub fn with_metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
+    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Tunnel backend metadata. Viewable via the dashboard and API, but has no
     /// bearing on tunnel behavior.
-    pub fn with_forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
+    pub fn with_forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// The TCP address to request for this edge.
-    pub fn with_remote_addr(&mut self, remote_addr: impl Into<String>) -> &mut Self {
+    pub fn with_remote_addr(mut self, remote_addr: impl Into<String>) -> Self {
         self.options.remote_addr = Some(remote_addr.into());
         self
     }
@@ -124,7 +124,7 @@ mod test {
         // pass to a function accepting the trait to avoid
         // "creates a temporary which is freed while still in use"
         tunnel_test(
-            &TcpTunnelBuilder {
+            TcpTunnelBuilder {
                 session: None,
                 options: Default::default(),
             }

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -25,9 +25,9 @@ use crate::{
         BindExtra,
         BindOpts,
     },
-    RpcError,
+    session::RpcError,
+    tunnel::TlsTunnel,
     Session,
-    TlsTunnel,
 };
 
 /// The options for TLS edges.

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -100,50 +100,50 @@ impl_builder! {
 impl TlsTunnelBuilder {
     /// Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_allow_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
+    pub fn with_allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_deny_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
+    pub fn with_deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// The version of PROXY protocol to use with this tunnel, None if not using.
-    pub fn with_proxy_proto(&mut self, proxy_proto: ProxyProto) -> &mut Self {
+    pub fn with_proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Tunnel-specific opaque metadata. Viewable via the API.
-    pub fn with_metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
+    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Tunnel backend metadata. Viewable via the dashboard and API, but has no
     /// bearing on tunnel behavior.
-    pub fn with_forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
+    pub fn with_forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// The domain to request for this edge.
-    pub fn with_domain(&mut self, domain: impl Into<String>) -> &mut Self {
+    pub fn with_domain(mut self, domain: impl Into<String>) -> Self {
         self.options.domain = Some(domain.into());
         self
     }
     /// Certificates to use for client authentication at the ngrok edge.
-    pub fn with_mutual_tlsca(&mut self, mutual_tlsca: Bytes) -> &mut Self {
+    pub fn with_mutual_tlsca(mut self, mutual_tlsca: Bytes) -> Self {
         self.options.mutual_tlsca.push(mutual_tlsca);
         self
     }
     /// The key to use for TLS termination at the ngrok edge in PEM format.
-    pub fn with_key_pem(&mut self, key_pem: Bytes) -> &mut Self {
+    pub fn with_key_pem(mut self, key_pem: Bytes) -> Self {
         self.options.key_pem = Some(key_pem);
         self
     }
     /// The certificate to use for TLS termination at the ngrok edge in PEM
     /// format.
-    pub fn with_cert_pem(&mut self, cert_pem: Bytes) -> &mut Self {
+    pub fn with_cert_pem(mut self, cert_pem: Bytes) -> Self {
         self.options.cert_pem = Some(cert_pem);
         self
     }

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
 
+use async_trait::async_trait;
 use prost::bytes::{
     self,
     Bytes,
 };
 
-use super::common::ProxyProto;
+use super::{
+    common::ProxyProto,
+    TunnelBuilder,
+};
 use crate::{
     config::common::{
         CommonOpts,
@@ -21,11 +25,14 @@ use crate::{
         BindExtra,
         BindOpts,
     },
+    RpcError,
+    Session,
+    TlsTunnel,
 };
 
 /// The options for TLS edges.
-#[derive(Default)]
-pub struct TLSEndpoint {
+#[derive(Default, Clone)]
+struct TlsOptions {
     pub(crate) common_opts: CommonOpts,
     pub(crate) domain: Option<String>,
     pub(crate) mutual_tlsca: Vec<bytes::Bytes>,
@@ -33,7 +40,7 @@ pub struct TLSEndpoint {
     pub(crate) cert_pem: Option<bytes::Bytes>,
 }
 
-impl TunnelConfig for TLSEndpoint {
+impl TunnelConfig for TlsOptions {
     fn forwards_to(&self) -> String {
         self.common_opts
             .forwards_to
@@ -85,54 +92,59 @@ impl TunnelConfig for TLSEndpoint {
     }
 }
 
-impl TLSEndpoint {
+impl_builder! {
+    /// A builder for a tunnel backing a TCP endpoint.
+    TlsTunnelBuilder, TlsOptions, TlsTunnel
+}
+
+impl TlsTunnelBuilder {
     /// Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
     pub fn with_allow_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
-        self.common_opts.cidr_restrictions.allow(cidr);
+        self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
     pub fn with_deny_cidr_string(&mut self, cidr: impl Into<String>) -> &mut Self {
-        self.common_opts.cidr_restrictions.deny(cidr);
+        self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// The version of PROXY protocol to use with this tunnel, None if not using.
     pub fn with_proxy_proto(&mut self, proxy_proto: ProxyProto) -> &mut Self {
-        self.common_opts.proxy_proto = proxy_proto;
+        self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Tunnel-specific opaque metadata. Viewable via the API.
     pub fn with_metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
-        self.common_opts.metadata = Some(metadata.into());
+        self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Tunnel backend metadata. Viewable via the dashboard and API, but has no
     /// bearing on tunnel behavior.
     pub fn with_forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
-        self.common_opts.forwards_to = Some(forwards_to.into());
+        self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// The domain to request for this edge.
     pub fn with_domain(&mut self, domain: impl Into<String>) -> &mut Self {
-        self.domain = Some(domain.into());
+        self.options.domain = Some(domain.into());
         self
     }
     /// Certificates to use for client authentication at the ngrok edge.
     pub fn with_mutual_tlsca(&mut self, mutual_tlsca: Bytes) -> &mut Self {
-        self.mutual_tlsca.push(mutual_tlsca);
+        self.options.mutual_tlsca.push(mutual_tlsca);
         self
     }
     /// The key to use for TLS termination at the ngrok edge in PEM format.
     pub fn with_key_pem(&mut self, key_pem: Bytes) -> &mut Self {
-        self.key_pem = Some(key_pem);
+        self.options.key_pem = Some(key_pem);
         self
     }
     /// The certificate to use for TLS termination at the ngrok edge in PEM
     /// format.
     pub fn with_cert_pem(&mut self, cert_pem: Bytes) -> &mut Self {
-        self.cert_pem = Some(cert_pem);
+        self.options.cert_pem = Some(cert_pem);
         self
     }
 }
@@ -156,17 +168,21 @@ mod test {
         // pass to a function accepting the trait to avoid
         // "creates a temporary which is freed while still in use"
         tunnel_test(
-            TLSEndpoint::default()
-                .with_allow_cidr_string(ALLOW_CIDR)
-                .with_deny_cidr_string(DENY_CIDR)
-                .with_proxy_proto(ProxyProto::V2)
-                .with_metadata(METADATA)
-                .with_domain(DOMAIN)
-                .with_mutual_tlsca(CA_CERT.into())
-                .with_mutual_tlsca(CA_CERT2.into())
-                .with_key_pem(KEY.into())
-                .with_cert_pem(CERT.into())
-                .with_forwards_to(TEST_FORWARD),
+            &TlsTunnelBuilder {
+                session: None,
+                options: Default::default(),
+            }
+            .with_allow_cidr_string(ALLOW_CIDR)
+            .with_deny_cidr_string(DENY_CIDR)
+            .with_proxy_proto(ProxyProto::V2)
+            .with_metadata(METADATA)
+            .with_domain(DOMAIN)
+            .with_mutual_tlsca(CA_CERT.into())
+            .with_mutual_tlsca(CA_CERT2.into())
+            .with_key_pem(KEY.into())
+            .with_cert_pem(CERT.into())
+            .with_forwards_to(TEST_FORWARD)
+            .options,
         );
     }
 

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -100,50 +100,50 @@ impl_builder! {
 impl TlsTunnelBuilder {
     /// Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
+    pub fn allow_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
     /// Call multiple times to add additional CIDR ranges.
-    pub fn with_deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
+    pub fn deny_cidr_string(mut self, cidr: impl Into<String>) -> Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// The version of PROXY protocol to use with this tunnel, None if not using.
-    pub fn with_proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
+    pub fn proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Tunnel-specific opaque metadata. Viewable via the API.
-    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Tunnel backend metadata. Viewable via the dashboard and API, but has no
     /// bearing on tunnel behavior.
-    pub fn with_forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
+    pub fn forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// The domain to request for this edge.
-    pub fn with_domain(mut self, domain: impl Into<String>) -> Self {
+    pub fn domain(mut self, domain: impl Into<String>) -> Self {
         self.options.domain = Some(domain.into());
         self
     }
     /// Certificates to use for client authentication at the ngrok edge.
-    pub fn with_mutual_tlsca(mut self, mutual_tlsca: Bytes) -> Self {
+    pub fn mutual_tlsca(mut self, mutual_tlsca: Bytes) -> Self {
         self.options.mutual_tlsca.push(mutual_tlsca);
         self
     }
     /// The key to use for TLS termination at the ngrok edge in PEM format.
-    pub fn with_key_pem(mut self, key_pem: Bytes) -> Self {
+    pub fn key_pem(mut self, key_pem: Bytes) -> Self {
         self.options.key_pem = Some(key_pem);
         self
     }
     /// The certificate to use for TLS termination at the ngrok edge in PEM
     /// format.
-    pub fn with_cert_pem(mut self, cert_pem: Bytes) -> Self {
+    pub fn cert_pem(mut self, cert_pem: Bytes) -> Self {
         self.options.cert_pem = Some(cert_pem);
         self
     }
@@ -172,16 +172,16 @@ mod test {
                 session: None,
                 options: Default::default(),
             }
-            .with_allow_cidr_string(ALLOW_CIDR)
-            .with_deny_cidr_string(DENY_CIDR)
-            .with_proxy_proto(ProxyProto::V2)
-            .with_metadata(METADATA)
-            .with_domain(DOMAIN)
-            .with_mutual_tlsca(CA_CERT.into())
-            .with_mutual_tlsca(CA_CERT2.into())
-            .with_key_pem(KEY.into())
-            .with_cert_pem(CERT.into())
-            .with_forwards_to(TEST_FORWARD)
+            .allow_cidr_string(ALLOW_CIDR)
+            .deny_cidr_string(DENY_CIDR)
+            .proxy_proto(ProxyProto::V2)
+            .metadata(METADATA)
+            .domain(DOMAIN)
+            .mutual_tlsca(CA_CERT.into())
+            .mutual_tlsca(CA_CERT2.into())
+            .key_pem(KEY.into())
+            .cert_pem(CERT.into())
+            .forwards_to(TEST_FORWARD)
             .options,
         );
     }

--- a/ngrok/src/internals/raw_session.rs
+++ b/ngrok/src/internals/raw_session.rs
@@ -56,16 +56,22 @@ use super::{
     },
 };
 
+/// Errors arising from tunneling protocol RPC calls.
 #[derive(Error, Debug)]
 pub enum RpcError {
+    /// Failed to open a new stream to start the RPC call.
     #[error("failed to open muxado stream")]
     Open(#[from] MuxadoError),
-    #[error("error reading rpc response")]
-    Send(#[source] io::Error),
+    /// Failed to send the request over the stream.
     #[error("error sending rpc request")]
+    Send(#[source] io::Error),
+    /// Failed to read the RPC response from the stream.
+    #[error("error reading rpc response")]
     Receive(#[source] io::Error),
+    /// The RPC response was invalid.
     #[error("failed to deserialize rpc response")]
     InvalidResponse(#[from] serde_json::Error),
+    /// There was an error in the RPC response.
     #[error("rpc error response: {0}")]
     Response(String),
 }

--- a/ngrok/src/lib.rs
+++ b/ngrok/src/lib.rs
@@ -9,14 +9,18 @@ mod internals {
     pub mod raw_session;
 }
 
+pub use internals::raw_session::RpcError;
+
 /// Tunnel and endpoint configuration types.
 pub mod config {
     // TODO: remove this once all of the config structs are fully fleshed out
     //       and tested.
     #![allow(dead_code)]
 
+    #[macro_use]
     mod common;
     pub use common::*;
+
     mod headers;
     mod http;
     pub use http::*;

--- a/ngrok/src/lib.rs
+++ b/ngrok/src/lib.rs
@@ -50,6 +50,7 @@ pub use tunnel::{
 
 /// A prelude of traits for working with ngrok types.
 pub mod prelude {
+    #[doc(inline)]
     pub use crate::{
         config::TunnelBuilder,
         tunnel::{

--- a/ngrok/src/lib.rs
+++ b/ngrok/src/lib.rs
@@ -9,8 +9,6 @@ mod internals {
     pub mod raw_session;
 }
 
-pub use internals::raw_session::RpcError;
-
 /// Tunnel and endpoint configuration types.
 pub mod config {
     // TODO: remove this once all of the config structs are fully fleshed out
@@ -37,8 +35,28 @@ pub mod config {
     mod webhook_verification;
 }
 
-mod session;
-mod tunnel;
+/// Types for working with the ngrok session.
+pub mod session;
+/// Types for working with ngrok tunnels.
+pub mod tunnel;
 
-pub use session::*;
-pub use tunnel::*;
+#[doc(inline)]
+pub use session::Session;
+#[doc(inline)]
+pub use tunnel::{
+    Conn,
+    Tunnel,
+};
+
+/// A prelude of traits for working with ngrok types.
+pub mod prelude {
+    pub use crate::{
+        config::TunnelBuilder,
+        tunnel::{
+            LabelsTunnel,
+            ProtoTunnel,
+            Tunnel,
+            UrlTunnel,
+        },
+    };
+}

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -160,14 +160,14 @@ pub struct InvalidAddrError(#[source] ParseIntError);
 
 impl SessionBuilder {
     /// Authenticate the ngrok session with the given authtoken.
-    pub fn with_authtoken(mut self, authtoken: impl Into<String>) -> Self {
+    pub fn authtoken(mut self, authtoken: impl Into<String>) -> Self {
         self.authtoken = Some(authtoken.into());
         self
     }
 
     /// Authenticate using the authtoken in the `NGROK_AUTHTOKEN` environment
     /// variable.
-    pub fn with_authtoken_from_env(mut self) -> Self {
+    pub fn authtoken_from_env(mut self) -> Self {
         self.authtoken = env::var("NGROK_AUTHTOKEN").ok();
         self
     }
@@ -175,7 +175,7 @@ impl SessionBuilder {
     /// Set the heartbeat interval for the session.
     /// This value determines how often we send application level
     /// heartbeats to the server go check connection liveness.
-    pub fn with_heartbeat_interval(mut self, heartbeat_interval: Duration) -> Self {
+    pub fn heartbeat_interval(mut self, heartbeat_interval: Duration) -> Self {
         self.heartbeat_interval = Some(heartbeat_interval);
         self
     }
@@ -183,20 +183,20 @@ impl SessionBuilder {
     /// Set the heartbeat tolerance for the session.
     /// If the session's heartbeats are outside of their interval by this duration,
     /// the server will assume the session is dead and close it.
-    pub fn with_heartbeat_tolerance(mut self, heartbeat_tolerance: Duration) -> Self {
+    pub fn heartbeat_tolerance(mut self, heartbeat_tolerance: Duration) -> Self {
         self.heartbeat_tolerance = Some(heartbeat_tolerance);
         self
     }
 
     /// Use the provided opaque metadata string for this session.
     /// Viewable from the ngrok dashboard or API.
-    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
         self.metadata = Some(metadata.into());
         self
     }
 
     /// Connect to the provided ngrok server address.
-    pub fn with_server_addr(mut self, addr: impl AsRef<str>) -> Result<Self, InvalidAddrError> {
+    pub fn server_addr(mut self, addr: impl AsRef<str>) -> Result<Self, InvalidAddrError> {
         let addr = addr.as_ref();
         let mut split = addr.split(':');
         let host = split.next().unwrap().into();
@@ -210,7 +210,7 @@ impl SessionBuilder {
     }
 
     /// Use the provided tls config when connecting to the ngrok server.
-    pub fn with_tls_config(mut self, config: rustls::ClientConfig) -> Self {
+    pub fn tls_config(mut self, config: rustls::ClientConfig) -> Self {
         self.tls_config = config;
         self
     }

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -28,6 +28,7 @@ use tokio_util::compat::{
 };
 use tracing::warn;
 
+pub use crate::internals::raw_session::RpcError;
 use crate::{
     config::{
         HttpTunnelBuilder,
@@ -46,13 +47,14 @@ use crate::{
             IncomingStreams,
             RawSession,
             RpcClient,
-            RpcError,
             StartSessionError,
         },
     },
-    AcceptError,
-    Conn,
-    TunnelInner,
+    tunnel::{
+        AcceptError,
+        Conn,
+        TunnelInner,
+    },
 };
 
 const CERT_BYTES: &[u8] = include_bytes!("../assets/ngrok.ca.crt");

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -160,14 +160,14 @@ pub struct InvalidAddrError(#[source] ParseIntError);
 
 impl SessionBuilder {
     /// Authenticate the ngrok session with the given authtoken.
-    pub fn with_authtoken(&mut self, authtoken: impl Into<String>) -> &mut Self {
+    pub fn with_authtoken(mut self, authtoken: impl Into<String>) -> Self {
         self.authtoken = Some(authtoken.into());
         self
     }
 
     /// Authenticate using the authtoken in the `NGROK_AUTHTOKEN` environment
     /// variable.
-    pub fn with_authtoken_from_env(&mut self) -> &mut Self {
+    pub fn with_authtoken_from_env(mut self) -> Self {
         self.authtoken = env::var("NGROK_AUTHTOKEN").ok();
         self
     }
@@ -175,7 +175,7 @@ impl SessionBuilder {
     /// Set the heartbeat interval for the session.
     /// This value determines how often we send application level
     /// heartbeats to the server go check connection liveness.
-    pub fn with_heartbeat_interval(&mut self, heartbeat_interval: Duration) -> &mut Self {
+    pub fn with_heartbeat_interval(mut self, heartbeat_interval: Duration) -> Self {
         self.heartbeat_interval = Some(heartbeat_interval);
         self
     }
@@ -183,23 +183,20 @@ impl SessionBuilder {
     /// Set the heartbeat tolerance for the session.
     /// If the session's heartbeats are outside of their interval by this duration,
     /// the server will assume the session is dead and close it.
-    pub fn with_heartbeat_tolerance(&mut self, heartbeat_tolerance: Duration) -> &mut Self {
+    pub fn with_heartbeat_tolerance(mut self, heartbeat_tolerance: Duration) -> Self {
         self.heartbeat_tolerance = Some(heartbeat_tolerance);
         self
     }
 
     /// Use the provided opaque metadata string for this session.
     /// Viewable from the ngrok dashboard or API.
-    pub fn with_metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
+    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Self {
         self.metadata = Some(metadata.into());
         self
     }
 
     /// Connect to the provided ngrok server address.
-    pub fn with_server_addr(
-        &mut self,
-        addr: impl AsRef<str>,
-    ) -> Result<&mut Self, InvalidAddrError> {
+    pub fn with_server_addr(mut self, addr: impl AsRef<str>) -> Result<Self, InvalidAddrError> {
         let addr = addr.as_ref();
         let mut split = addr.split(':');
         let host = split.next().unwrap().into();
@@ -213,7 +210,7 @@ impl SessionBuilder {
     }
 
     /// Use the provided tls config when connecting to the ngrok server.
-    pub fn with_tls_config(&mut self, config: rustls::ClientConfig) -> &mut Self {
+    pub fn with_tls_config(mut self, config: rustls::ClientConfig) -> Self {
         self.tls_config = config;
         self
     }

--- a/ngrok/src/tunnel.rs
+++ b/ngrok/src/tunnel.rs
@@ -10,10 +10,7 @@ use std::{
 
 use async_trait::async_trait;
 use axum::extract::connect_info::Connected;
-use futures::{
-    Stream,
-    TryStreamExt,
-};
+use futures::Stream;
 use hyper::server::accept::Accept;
 use muxado::{
     typed::TypedStream,
@@ -141,11 +138,6 @@ impl Accept for TunnelInner {
 }
 
 impl TunnelInner {
-    /// Accept an incomming connection on this tunnel.
-    pub async fn accept(&mut self) -> Result<Option<Conn>, AcceptError> {
-        self.try_next().await
-    }
-
     /// Get this tunnel's ID as returned by the ngrok server.
     pub fn id(&self) -> &str {
         &self.id


### PR DESCRIPTION
Makes the following changes:
* Inverts the tunnel builders such that they hold a clone of the session.
  This lets the builders start themselves. By cloning the session, they're also detached from the original session's lifetime, and can be passed around to start tunnels from a common configuration.
* Adds multiple tunnel types with minimal interfaces
  This prevents the caller from trying to, say, get the URL of a labeled tunnel that doesn't know its URL.
* Adds a `TunnelBuilder` trait.
  As with the other traits added, might be a bit controversial. But could be handy for anyone wanting to take a generic tunnel config and use it to repeatedly produce tunnels, without caring too much about how they're configured. This trait also defines the `Tunnel` type that the builder produces.
* Adds some `Tunnel` traits.
  We said we probably wouldn't need these, but once we have multiple tunnel types, it starts to make some more sense. Even if people *should* be using standard traits like `Stream` and `Accept`, the fact of the matter is that our types *will* implement some common functionality that we should let consumers be generic over if they need to.
* Unifies the approach to the builder pattern
  Kinda a side change, but kinda not. Standardizes on the "by-value" approach to builders. Since the tunnel builders are `'static`, they can be passed around and it makes less sense for them to *always* be `.listen()`'ed immediately. With the "by-mutable-reference" approach, that's less of a possibility unless you bind the builder variable in one statement, call the methods in another, and then pass it along in yet another. Callers will now have to `b = b.method(whatever);` if they want to update their builder in-place, but that's the tradeoff :shrug: This also allows consumers to "fork" the builder by cloning it and applying different config to the clones, which can be useful as well.
* Shuffle the exports (again)
  I discovered that you can `#[doc(inline)]` for re-exports, so I feel a bit less strongly about putting errors in one central `errors` module. It makes more sense to put them next to the code where they're produced, and leave the modules exported. Re-exports at the root are there for ergonomics for the most important types (`Session`, `Tunnel`, and `Conn`).
* (cont., kinda) Add a prelude
  This is a new export that just contains all of our traits. Very common pattern in rust, and more important now that we've actually got a pile of them.
* Switch the examples to use `ngrok::Session` and a single `use ngrok::prelude::*;` import
  Cleans things up a lot. I'm pretty happy with how it turned out. They also now use the tunnel traits since they're all using different tunnel types. There ends up being a bit less example drift as a result.
* Remove the `with_` prefix on builder methods
  I'm actually less sure I like this change. After we discussed it, I found all sorts of counterexamples where builder methods *do* have it. See the tracing subscriber setup in the examples and the tls configuration during session connect.