### PR TITLE
ngrok: add tunnel extension to allow connection forwarding

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1669616799,
-        "narHash": "sha256-cTe0E41+4h3LS7NtYd+LdE2ngvIBZ5VIQflT4qu+z9I=",
+        "lastModified": 1671603776,
+        "narHash": "sha256-4OcAK1IUqvjf7cS175YRI3GOVNE5t5iSCqN30lfDGFk=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "864fe18d688b0c8c0730bb179b6686eac951f613",
+        "rev": "e419ca16500d124af816dbed1fbab6910327b8b3",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669597967,
-        "narHash": "sha256-R+2NaDkXsYkOpFOhmVR8jBZ77Pq55Z6ilaqwFLLn000=",
+        "lastModified": 1671458120,
+        "narHash": "sha256-2+k/OONN4OF21TeoNjKB5sXVZv6Zvm/uEyQIW9OYCg8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "be9e3762e719211368d186f547f847737baad720",
+        "rev": "e37ef84b478fa8da0ced96522adfd956fde9047a",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1669551522,
-        "narHash": "sha256-ScH3I2/5+tCN23U8mUUj/HoZXDF11fo1z93X9imAfOo=",
+        "lastModified": 1671570698,
+        "narHash": "sha256-RMNCapv21wVNx9dRNbStiP/aTrWTl9QbJjXlKcuxK3I=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "6d61be8e65ac0fd45eaf178e1f7a1ec6b582de1f",
+        "rev": "761b127c473f8324bc9fe46a3fb502bb0a8ba6ba",
         "type": "github"
       },
       "original": {

--- a/ngrok/examples/mingrok.rs
+++ b/ngrok/examples/mingrok.rs
@@ -1,0 +1,28 @@
+use anyhow::Error;
+use ngrok::prelude::*;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .pretty()
+        .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let forwards_to = std::env::args()
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("missing forwarding address"))?;
+
+    let mut tun = ngrok::Session::builder()
+        .authtoken_from_env()
+        .connect()
+        .await?
+        .http_endpoint()
+        .forwards_to(&forwards_to)
+        .listen()
+        .await?;
+
+    info!(url = tun.url(), forwards_to, "started tunnel");
+
+    Ok(tun.forward_http(forwards_to).await?)
+}

--- a/ngrok/src/lib.rs
+++ b/ngrok/src/lib.rs
@@ -40,6 +40,8 @@ pub mod session;
 /// Types for working with ngrok tunnels.
 pub mod tunnel;
 
+mod tunnel_ext;
+
 #[doc(inline)]
 pub use session::Session;
 #[doc(inline)]
@@ -59,5 +61,6 @@ pub mod prelude {
             Tunnel,
             UrlTunnel,
         },
+        tunnel_ext::TunnelExt,
     };
 }

--- a/ngrok/src/tunnel_ext.rs
+++ b/ngrok/src/tunnel_ext.rs
@@ -173,7 +173,7 @@ fn serve_gateway_error(
                     service_fn(move |_req| {
                         debug!("serving bad gateway error");
                         let mut resp =
-                            Response::new(Body::from(format!("failed to dial backend: {}", err)));
+                            Response::new(Body::from(format!("failed to dial backend: {err}")));
                         *resp.status_mut() = StatusCode::BAD_GATEWAY;
                         futures::future::ok::<_, Infallible>(resp)
                     }),

--- a/ngrok/src/tunnel_ext.rs
+++ b/ngrok/src/tunnel_ext.rs
@@ -1,0 +1,188 @@
+use std::{
+    convert::Infallible,
+    fmt,
+    io,
+    net::SocketAddr,
+};
+
+use async_trait::async_trait;
+use futures::stream::TryStreamExt;
+use hyper::{
+    server::conn::Http,
+    service::service_fn,
+    Body,
+    Response,
+    StatusCode,
+};
+use tokio::{
+    io::{
+        AsyncRead,
+        AsyncReadExt,
+        AsyncWrite,
+        AsyncWriteExt,
+    },
+    net::{
+        TcpStream,
+        ToSocketAddrs,
+    },
+    task::JoinHandle,
+};
+use tracing::{
+    debug,
+    field,
+    instrument,
+    trace,
+    warn,
+    Instrument,
+    Span,
+};
+
+use crate::{
+    prelude::*,
+    Conn,
+};
+
+impl<T> TunnelExt for T where T: Tunnel {}
+
+/// Extension methods auto-implemented for all tunnel types
+#[async_trait]
+pub trait TunnelExt: Tunnel {
+    /// Forward incoming tunnel connections to the provided TCP address.
+    #[instrument(level = "debug", skip_all, fields(local_addrs))]
+    async fn forward_tcp(&mut self, addr: impl ToSocketAddrs + Send) -> Result<(), io::Error> {
+        forward_conns(self, addr, |_, _| {}).await
+    }
+
+    /// Forward incoming tunnel connections to the provided TCP address.
+    ///
+    /// Provides slightly nicer errors when the backend is unavailable.
+    #[instrument(level = "debug", skip_all, fields(local_addrs))]
+    async fn forward_http(&mut self, addr: impl ToSocketAddrs + Send) -> Result<(), io::Error> {
+        forward_conns(self, addr, |e, c| drop(serve_gateway_error(e, c))).await
+    }
+}
+
+async fn forward_conns<T, A, F>(this: &mut T, addr: A, mut on_err: F) -> Result<(), io::Error>
+where
+    T: Tunnel + ?Sized,
+    A: ToSocketAddrs,
+    F: FnMut(io::Error, Conn),
+{
+    let span = Span::current();
+    let addrs = tokio::net::lookup_host(addr).await?.collect::<Vec<_>>();
+    span.record("local_addrs", field::debug(&addrs));
+    trace!("looked up local addrs");
+    loop {
+        trace!("waiting for new tunnel connection");
+        if !handle_one(this, addrs.as_slice(), &mut on_err).await? {
+            debug!("listener closed, exiting");
+            break;
+        }
+    }
+    Ok(())
+}
+
+async fn forward_bytes(
+    mut r: impl AsyncRead + Unpin,
+    mut w: impl AsyncWrite + Unpin,
+) -> Result<(), io::Error> {
+    let mut buf = vec![0u8; 1024];
+    loop {
+        let n = r.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+
+        w.write_all(&buf[0..n]).await?;
+    }
+    Ok(())
+}
+
+fn join_streams(
+    left: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    right: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+) -> JoinHandle<()> {
+    let (t_rx, t_tx) = tokio::io::split(left);
+    let (l_rx, l_tx) = tokio::io::split(right);
+
+    let joined = futures::future::join(forward_bytes(t_rx, l_tx), forward_bytes(l_rx, t_tx));
+    tokio::spawn(
+        async move {
+            let (to_tunnel, to_local) = joined.await;
+            debug!(?to_tunnel, ?to_local, "connection closed");
+        }
+        .in_current_span(),
+    )
+}
+
+#[instrument(level = "debug", skip_all, fields(remote_addr, local_addr))]
+async fn handle_one<T, F>(
+    this: &mut T,
+    addrs: &[SocketAddr],
+    on_error: F,
+) -> Result<bool, io::Error>
+where
+    T: Tunnel + ?Sized,
+    F: FnOnce(io::Error, Conn),
+{
+    let span = Span::current();
+    let tunnel_conn = if let Some(conn) = this
+        .try_next()
+        .await
+        .map_err(|err| io::Error::new(io::ErrorKind::NotConnected, err))?
+    {
+        conn
+    } else {
+        return Ok(false);
+    };
+
+    span.record("remote_addr", field::debug(tunnel_conn.remote_addr()));
+
+    trace!("accepted tunnel connection");
+
+    let local_conn = match TcpStream::connect(addrs).await {
+        Ok(conn) => conn,
+        Err(error) => {
+            warn!(%error, "error establishing local connection");
+
+            on_error(error, tunnel_conn);
+
+            return Ok(true);
+        }
+    };
+    span.record("local_addr", field::debug(local_conn.peer_addr().unwrap()));
+
+    trace!("established local connection");
+
+    debug!("forwarding tunnel connection to local address");
+
+    join_streams(tunnel_conn, local_conn);
+    Ok(true)
+}
+
+#[allow(dead_code)]
+fn serve_gateway_error(
+    err: impl fmt::Display + Send + 'static,
+    stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+) -> JoinHandle<()> {
+    tokio::spawn(
+        async move {
+            let res = Http::new()
+                .http1_only(true)
+                .http1_keep_alive(false)
+                .serve_connection(
+                    stream,
+                    service_fn(move |_req| {
+                        debug!("serving bad gateway error");
+                        let mut resp =
+                            Response::new(Body::from(format!("failed to dial backend: {}", err)));
+                        *resp.status_mut() = StatusCode::BAD_GATEWAY;
+                        futures::future::ok::<_, Infallible>(resp)
+                    }),
+                )
+                .await;
+            debug!(?res, "connection closed");
+        }
+        .in_current_span(),
+    )
+}


### PR DESCRIPTION
I'm also using this as an excuse to play around with tracing/fields/etc. again.

This is what the mingrok logs look like when you have debug enabled for the tunnel module:

```
RUST_LOG=ngrok::tunnel=debug,ngrok=info,mingrok=info cargo run --example mingrok localhost:12345
   Compiling muxado v0.1.0 (/home/josh/src/github.com/ngrok/ngrok-rs/muxado)
   Compiling ngrok v0.1.0 (/home/josh/src/github.com/ngrok/ngrok-rs/ngrok)
    Finished dev [unoptimized + debuginfo] target(s) in 10.05s
     Running `target/debug/examples/mingrok 'localhost:12345'`
  2022-12-21T19:14:30.900010Z  INFO mingrok: started tunnel, url: "https://3b74b4b29a73.ngrok.app", forwards_to: "localhost:12345"
    at ngrok/examples/mingrok.rs:25

  2022-12-21T19:14:34.481864Z  WARN ngrok::tunnel_ext: error establishing local connection, error: Connection refused (os error 111)
    at ngrok/src/tunnel_ext.rs:146
    in ngrok::tunnel_ext::handle_one with remote_addr: 217.180.201.69:17842
    in ngrok::tunnel_ext::forward_http with local_addrs: [[::1]:12345, 127.0.0.1:12345]

  2022-12-21T19:14:34.482830Z DEBUG ngrok::tunnel_ext: serving bad gateway error
    at ngrok/src/tunnel_ext.rs:176
    in ngrok::tunnel_ext::handle_one with remote_addr: 217.180.201.69:17842
    in ngrok::tunnel_ext::forward_http with local_addrs: [[::1]:12345, 127.0.0.1:12345]

  2022-12-21T19:14:34.483281Z DEBUG ngrok::tunnel_ext: connection closed, res: Ok(())
    at ngrok/src/tunnel_ext.rs:184
    in ngrok::tunnel_ext::handle_one with remote_addr: 217.180.201.69:17842
    in ngrok::tunnel_ext::forward_http with local_addrs: [[::1]:12345, 127.0.0.1:12345]

  2022-12-21T19:14:34.697742Z  WARN ngrok::tunnel_ext: error establishing local connection, error: Connection refused (os error 111)
    at ngrok/src/tunnel_ext.rs:146
    in ngrok::tunnel_ext::handle_one with remote_addr: 217.180.201.69:17842
    in ngrok::tunnel_ext::forward_http with local_addrs: [[::1]:12345, 127.0.0.1:12345]

  2022-12-21T19:14:34.698614Z DEBUG ngrok::tunnel_ext: serving bad gateway error
    at ngrok/src/tunnel_ext.rs:176
    in ngrok::tunnel_ext::handle_one with remote_addr: 217.180.201.69:17842
    in ngrok::tunnel_ext::forward_http with local_addrs: [[::1]:12345, 127.0.0.1:12345]

  2022-12-21T19:14:34.698988Z DEBUG ngrok::tunnel_ext: connection closed, res: Ok(())
    at ngrok/src/tunnel_ext.rs:184
    in ngrok::tunnel_ext::handle_one with remote_addr: 217.180.201.69:17842
    in ngrok::tunnel_ext::forward_http with local_addrs: [[::1]:12345, 127.0.0.1:12345]

  2022-12-21T19:14:51.437951Z DEBUG ngrok::tunnel_ext: forwarding tunnel connection to local address
    at ngrok/src/tunnel_ext.rs:157
    in ngrok::tunnel_ext::handle_one with remote_addr: 217.180.201.69:17842, local_addr: 127.0.0.1:12345
    in ngrok::tunnel_ext::forward_http with local_addrs: [[::1]:12345, 127.0.0.1:12345]

  2022-12-21T19:14:54.151063Z DEBUG ngrok::tunnel_ext: connection closed, to_tunnel: Ok(()), to_local: Ok(())
    at ngrok/src/tunnel_ext.rs:112
    in ngrok::tunnel_ext::handle_one with remote_addr: 217.180.201.69:17842, local_addr: 127.0.0.1:12345
    in ngrok::tunnel_ext::forward_http with local_addrs: [[::1]:12345, 127.0.0.1:12345]
```