### PR TITLE
nix: add some common hooks and helpers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,19 +26,59 @@
             fenix-flake.overlays.default
           ];
         };
+        toolchain = pkgs.fenix.complete.withComponents [
+          "cargo"
+          "clippy"
+          "rust-src"
+          "rustc"
+          "rustfmt"
+        ];
+        fix-n-fmt = pkgs.writeShellScriptBin "fix-n-fmt" ''
+          set -euf -o pipefail
+          ${toolchain}/bin/cargo clippy --fix --allow-staged --allow-dirty --all-targets
+          ${toolchain}/bin/cargo fmt
+        '';
+        pre-commit = pkgs.writeShellScript "pre-commit" ''
+          cargo clippy --all-targets -- -D warnings
+          result=$?
+
+          if [[ ''${result} -ne 0 ]] ; then
+              cat <<\EOF
+          There are some linting issues, try `fix-n-fmt` to fix.
+          EOF
+              exit 1
+          fi
+
+          diff=$(cargo fmt -- --check)
+          result=$?
+
+          if [[ ''${result} -ne 0 ]] ; then
+              cat <<\EOF
+          There are some code style issues, run `fix-n-fmt` first.
+          EOF
+              exit 1
+          fi
+
+          exit 0
+        '';
+        setup-hooks = pkgs.writeShellScriptBin "setup-hooks" ''
+          repo_root=$(git rev-parse --git-dir)
+
+          ${toString (map (h: ''
+            ln -sf ${h} ''${repo_root}/hooks/${h.name}
+          '') [
+            pre-commit
+          ])}
+        '';
       in
       {
         devShell = pkgs.mkShell {
           CHALK_OVERFLOW_DEPTH = 3000;
           CHALK_SOLVER_MAX_SIZE = 1500;
           buildInputs = with pkgs; [
-            (fenix.complete.withComponents [
-              "cargo"
-              "clippy"
-              "rust-src"
-              "rustc"
-              "rustfmt"
-            ])
+            toolchain
+            fix-n-fmt
+            setup-hooks
             cargo-udeps
           ];
         };


### PR DESCRIPTION
Tired of running this big ol' clippy + fmt command by hand, and tired of committing stuff that CI yells at me about.

The pre-commit hook is opt-in, so you can skip it entirely if you want. You have to re-run the `setup-hooks` command if we change the contents of the hook, but since it uses the `PATH` to find cargo & co, it shouldn't need to be re-run if we just update toolchain versions and such.