### PR TITLE
tunnel proto fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
-      - run: curl -sfL https://direnv.net/install.sh | bash
+      - run: curl --retry 5 --retry-all-errors -sfL https://direnv.net/install.sh | bash
       - run: direnv allow
       - run: direnv export gha >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
-      - run: curl -sfL https://direnv.net/install.sh | bash
+      - run: curl --retry 5 --retry-all-errors -sfL https://direnv.net/install.sh | bash
       - run: direnv allow
       - run: direnv export gha >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
-      - run: curl -sfL https://direnv.net/install.sh | bash
+      - run: curl --retry 5 --retry-all-errors -sfL https://direnv.net/install.sh | bash
       - run: direnv allow
       - run: direnv export gha >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
-      - run: curl -sfL https://direnv.net/install.sh | bash
+      - run: curl --retry 5 --retry-all-errors -sfL https://direnv.net/install.sh | bash
       - run: direnv allow
       - run: direnv export gha >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -91,7 +91,7 @@ impl TunnelConfig for HttpOptions {
         let http_endpoint = HttpEndpoint {
             proxy_proto: self.common_opts.proxy_proto,
             hostname: self.domain.clone().unwrap_or_default(),
-            compression: self.compression.then_some(Compression),
+            compression: self.compression.then_some(Compression {}),
             circuit_breaker: (self.circuit_breaker != 0f64).then_some(CircuitBreaker {
                 error_threshold: self.circuit_breaker,
             }),
@@ -112,7 +112,7 @@ impl TunnelConfig for HttpOptions {
                 .then_some(self.response_headers.clone().into()),
             websocket_tcp_converter: self
                 .websocket_tcp_conversion
-                .then_some(WebsocketTcpConverter),
+                .then_some(WebsocketTcpConverter {}),
             ..Default::default()
         };
 

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -263,7 +263,7 @@ impl HttpTunnelBuilder {
     ) -> Self {
         self.options.webhook_verification = Some(WebhookVerification {
             provider: provider.into(),
-            secret: secret.into(),
+            secret: secret.into().into(),
         });
         self
     }
@@ -333,7 +333,7 @@ mod test {
         assert_eq!(TEST_FORWARD, tunnel_cfg.forwards_to());
 
         let extra = tunnel_cfg.extra();
-        assert_eq!(String::default(), extra.token);
+        assert_eq!(String::default(), *extra.token);
         assert_eq!(METADATA, extra.metadata);
         assert_eq!(String::default(), extra.ip_policy_ref);
 
@@ -369,7 +369,7 @@ mod test {
 
             let webhook = endpoint.webhook_verification.unwrap();
             assert_eq!("twilio", webhook.provider);
-            assert_eq!("asdf", webhook.secret);
+            assert_eq!("asdf", *webhook.secret);
             assert!(webhook.sealed_secret.is_empty());
 
             let creds = endpoint.basic_auth.unwrap().credentials;
@@ -384,7 +384,7 @@ mod test {
             assert_eq!(["<domain>"].to_vec(), oauth.allow_domains);
             assert_eq!(["<scope>"].to_vec(), oauth.scopes);
             assert_eq!(String::default(), oauth.client_id);
-            assert_eq!(String::default(), oauth.client_secret);
+            assert_eq!(String::default(), *oauth.client_secret);
             assert!(oauth.sealed_client_secret.is_empty());
 
             let oidc = endpoint.oidc.unwrap();
@@ -393,7 +393,7 @@ mod test {
             assert_eq!(["<domain>"].to_vec(), oidc.allow_domains);
             assert_eq!(["<scope>"].to_vec(), oidc.scopes);
             assert_eq!("<id>", oidc.client_id);
-            assert_eq!("<secret>", oidc.client_secret);
+            assert_eq!("<secret>", *oidc.client_secret);
             assert!(oidc.sealed_client_secret.is_empty());
         }
 

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -99,7 +99,7 @@ mod test {
         assert_eq!(FORWARDS_TO, tunnel_cfg.forwards_to());
 
         let extra = tunnel_cfg.extra();
-        assert_eq!(String::default(), extra.token);
+        assert_eq!(String::default(), *extra.token);
         assert_eq!(METADATA, extra.metadata);
         assert_eq!(String::default(), extra.ip_policy_ref);
 

--- a/ngrok/src/config/oidc.rs
+++ b/ngrok/src/config/oidc.rs
@@ -1,11 +1,14 @@
-use crate::internals::proto::Oidc;
+use crate::internals::proto::{
+    Oidc,
+    SecretString,
+};
 
 /// Oidc Options configuration
 #[derive(Clone, Default)]
 pub struct OidcOptions {
     issuer_url: String,
     client_id: String,
-    client_secret: String,
+    client_secret: SecretString,
     allow_emails: Vec<String>,
     allow_domains: Vec<String>,
     scopes: Vec<String>,
@@ -21,7 +24,7 @@ impl OidcOptions {
         OidcOptions {
             issuer_url: issuer_url.into(),
             client_id: client_id.into(),
-            client_secret: client_secret.into(),
+            client_secret: client_secret.into().into(),
             ..Default::default()
         }
     }

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -142,7 +142,7 @@ mod test {
         assert_eq!(TEST_FORWARD, tunnel_cfg.forwards_to());
 
         let extra = tunnel_cfg.extra();
-        assert_eq!(String::default(), extra.token);
+        assert_eq!(String::default(), *extra.token);
         assert_eq!(METADATA, extra.metadata);
         assert_eq!(String::default(), extra.ip_policy_ref);
 

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -71,7 +71,7 @@ impl TunnelConfig for TlsOptions {
             .zip(self.key_pem.as_ref())
             .map(|(c, k)| TlsTermination {
                 cert: c.to_vec(),
-                key: k.to_vec(),
+                key: k.to_vec().into(),
                 sealed_key: Vec::new(),
             });
 
@@ -188,7 +188,7 @@ mod test {
         assert_eq!(TEST_FORWARD, tunnel_cfg.forwards_to());
 
         let extra = tunnel_cfg.extra();
-        assert_eq!(String::default(), extra.token);
+        assert_eq!(String::default(), *extra.token);
         assert_eq!(METADATA, extra.metadata);
         assert_eq!(String::default(), extra.ip_policy_ref);
 
@@ -208,7 +208,7 @@ mod test {
 
             let tls_termination = endpoint.tls_termination.unwrap();
             assert_eq!(CERT, tls_termination.cert);
-            assert_eq!(KEY, tls_termination.key);
+            assert_eq!(KEY, *tls_termination.key);
             assert!(tls_termination.sealed_key.is_empty());
 
             let mutual_tls = endpoint.mutual_tls_at_edge.unwrap();

--- a/ngrok/src/config/webhook_verification.rs
+++ b/ngrok/src/config/webhook_verification.rs
@@ -1,4 +1,7 @@
-use crate::internals::proto::WebhookVerification as WebhookProto;
+use crate::internals::proto::{
+    SecretString,
+    WebhookVerification as WebhookProto,
+};
 
 /// Configuration for webhook verification.
 #[derive(Clone)]
@@ -6,7 +9,7 @@ pub(crate) struct WebhookVerification {
     /// The webhook provider
     pub(crate) provider: String,
     /// The secret for verifying webhooks from this provider.
-    pub(crate) secret: String,
+    pub(crate) secret: SecretString,
 }
 
 impl WebhookVerification {}

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -330,7 +330,7 @@ rpc_req!(Update, UpdateResp, UPDATE_REQ);
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
 #[serde(rename_all = "PascalCase")]
-pub struct SrvInfo;
+pub struct SrvInfo {}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "PascalCase")]
@@ -457,96 +457,120 @@ pub struct HttpEndpoint {
     pub webhook_verification: Option<WebhookVerification>,
     #[serde(rename = "MutualTLSCA")]
     pub mutual_tls_ca: Option<MutualTls>,
+    #[serde(default)]
     pub request_headers: Option<Headers>,
+    #[serde(default)]
     pub response_headers: Option<Headers>,
     #[serde(rename = "WebsocketTCPConverter")]
     pub websocket_tcp_converter: Option<WebsocketTcpConverter>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct Compression;
+pub struct Compression {}
+
+fn is_default<T>(v: &T) -> bool
+where
+    T: PartialEq<T> + Default,
+{
+    T::default() == *v
+}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
 pub struct CircuitBreaker {
+    #[serde(default, skip_serializing_if = "is_default")]
     pub error_threshold: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
 pub struct BasicAuth {
+    #[serde(default, skip_serializing_if = "is_default")]
     pub credentials: Vec<BasicAuthCredential>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct BasicAuthCredential {
     pub username: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub cleartext_password: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     #[serde(with = "base64bytes")]
     pub hashed_password: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
 pub struct IpRestriction {
+    #[serde(default, skip_serializing_if = "is_default")]
     pub allow_cidrs: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub deny_cidrs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
 pub struct Oauth {
     pub provider: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub client_id: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub client_secret: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     #[serde(with = "base64bytes")]
     pub sealed_client_secret: Vec<u8>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub allow_emails: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub allow_domains: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub scopes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
 pub struct Oidc {
     pub issuer_url: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub client_id: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub client_secret: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     #[serde(with = "base64bytes")]
     pub sealed_client_secret: Vec<u8>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub allow_emails: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub allow_domains: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub scopes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
 pub struct WebhookVerification {
     pub provider: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub secret: String,
+    #[serde(default, skip_serializing_if = "is_default")]
     #[serde(with = "base64bytes")]
     pub sealed_secret: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
 pub struct MutualTls {
+    #[serde(default, skip_serializing_if = "is_default")]
     #[serde(with = "base64bytes")]
     pub mutual_tls_ca: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "camelCase")]
 pub struct Headers {
+    #[serde(default, skip_serializing_if = "is_default")]
     pub add: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub remove: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub add_parsed: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct WebsocketTcpConverter;
+pub struct WebsocketTcpConverter {}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "PascalCase")]
@@ -571,13 +595,12 @@ pub struct TlsEndpoint {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "PascalCase")]
 pub struct TlsTermination {
-    #[serde(with = "base64bytes")]
+    #[serde(with = "base64bytes", skip_serializing_if = "is_default")]
     pub cert: Vec<u8>,
-    #[serde(with = "base64bytes")]
+    #[serde(with = "base64bytes", skip_serializing_if = "is_default")]
     pub key: Vec<u8>,
-    #[serde(with = "base64bytes")]
+    #[serde(with = "base64bytes", skip_serializing_if = "is_default")]
     pub sealed_key: Vec<u8>,
 }
 
@@ -598,14 +621,12 @@ mod base64bytes {
     };
 
     pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
-        let base64 = base64::encode(v);
-        String::serialize(&base64, s)
+        base64::encode(v).serialize(s)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
-        let base64 = String::deserialize(d)?;
-        let bytes = base64::decode(base64.as_bytes()).map_err(serde::de::Error::custom)?;
-        Ok(bytes)
+        let s = String::deserialize(d)?;
+        base64::decode(s.as_bytes()).map_err(serde::de::Error::custom)
     }
 }
 

--- a/ngrok/src/internals/raw_session.rs
+++ b/ngrok/src/internals/raw_session.rs
@@ -179,12 +179,7 @@ impl RpcClient {
             .await
             .map_err(RpcError::Receive)?;
 
-        debug!(
-            resp_string = String::from_utf8_lossy(&buf).as_ref(),
-            "read rpc response"
-        );
-
-        #[derive(Deserialize)]
+        #[derive(Debug, Deserialize)]
         struct ErrResp {
             #[serde(rename = "Error")]
             error: String,
@@ -195,9 +190,12 @@ impl RpcClient {
 
         if let Ok(err) = err_resp {
             if !err.error.is_empty() {
+                debug!(?err, "decoded rpc error response");
                 return Err(RpcError::Response(err.error));
             }
         }
+
+        debug!(resp = ?ok_resp, "decoded rpc response");
 
         Ok(ok_resp?)
     }

--- a/ngrok/src/internals/rpc.rs
+++ b/ngrok/src/internals/rpc.rs
@@ -3,33 +3,12 @@ use std::fmt::Debug;
 use muxado::typed::StreamType;
 use serde::{
     de::DeserializeOwned,
-    Deserialize,
     Serialize,
 };
-
-use super::raw_session::RpcError;
 
 pub trait RpcRequest: Serialize + Debug {
     type Response: DeserializeOwned + Debug;
     const TYPE: StreamType;
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-pub struct RpcResult<T> {
-    #[serde(flatten)]
-    ok: Option<T>,
-    #[serde(default, rename = "Error")]
-    error: String,
-}
-
-impl<T> From<RpcResult<T>> for Result<T, RpcError> {
-    fn from(res: RpcResult<T>) -> Self {
-        if res.error.is_empty() && res.ok.is_some() {
-            Ok(res.ok.unwrap())
-        } else {
-            Err(RpcError::Response(res.error))
-        }
-    }
 }
 
 macro_rules! rpc_req {

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -60,6 +60,7 @@ use crate::{
             AuthExtra,
             BindExtra,
             BindOpts,
+            SecretString,
         },
         raw_session::{
             AcceptError as RawAcceptError,
@@ -153,14 +154,14 @@ fn default_connect() -> ConnectCallback {
 /// The builder for an ngrok [Session].
 #[derive(Clone)]
 pub struct SessionBuilder {
-    authtoken: Option<String>,
+    authtoken: Option<SecretString>,
     metadata: Option<String>,
     heartbeat_interval: Option<Duration>,
     heartbeat_tolerance: Option<Duration>,
     server_addr: String,
     tls_config: rustls::ClientConfig,
     connect_callback: ConnectCallback,
-    cookie: Option<String>,
+    cookie: Option<SecretString>,
     id: Option<String>,
 }
 
@@ -244,14 +245,14 @@ impl Default for SessionBuilder {
 impl SessionBuilder {
     /// Authenticate the ngrok session with the given authtoken.
     pub fn authtoken(mut self, authtoken: impl Into<String>) -> Self {
-        self.authtoken = Some(authtoken.into());
+        self.authtoken = Some(authtoken.into().into());
         self
     }
 
     /// Authenticate using the authtoken in the `NGROK_AUTHTOKEN` environment
     /// variable.
     pub fn authtoken_from_env(mut self) -> Self {
-        self.authtoken = env::var("NGROK_AUTHTOKEN").ok();
+        self.authtoken = env::var("NGROK_AUTHTOKEN").ok().map(From::from);
         self
     }
 


### PR DESCRIPTION
I'm rolling up any protocol changes needed to get #38 working here to keep things somewhat organized.

For the most part, this is just making sure that these structs I added match the json representation generated by protoc, which annoyingly is *completely different* from the hand-written Go structs. This means that all of their fields get defaulted and omitted if they're default, as well as snake_cased, *except* for the `Headers::add_parsed` field, which is inexplicably camelCase in the proto definition.