### PR TITLE
Prepare for release on crates-io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 /Cargo.lock
 .direnv
+/.vscode
 *.swp

--- a/ngrok/CHANGELOG.md
+++ b/ngrok/CHANGELOG.md
@@ -1,0 +1,11 @@
+
+## 0.7.0
+
+* Initial crates.io release.
+
+## Pre-0.7.0
+
+* There was originally a crate on crates.io named 'ngrok' that wrapped the agent
+  binary. It can be found [here](https://github.com/nkconnor/ngrok).
+
+  Thanks @nkconnor!

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/README.md
+++ b/ngrok/README.md
@@ -1,10 +1,15 @@
 # ngrok-rs
 
-**Note: This is alpha-quality software. Interfaces are subject to change without warning.**
+**Note: This is alpha-quality software. Interfaces may change without warning.**
+
 
 ngrok is a globally distributed reverse proxy commonly used for quickly getting a public URL to a service running inside a private network, such as on your local laptop. The ngrok agent is usually deployed inside a private network and is used to communicate with the ngrok cloud service.
 
 This is the ngrok agent in library form, suitable for integrating directly into Go applications. This allows you to quickly build ngrok into your application with no separate process to manage. 
+
+If you're looking for the agent wrapper, it's over
+[here](https://github.com/nkconnor/ngrok). See [UPGRADING.md](./UPGRADING.md)
+for tips on migrating.
 
 # License
 

--- a/ngrok/UPGRADING.md
+++ b/ngrok/UPGRADING.md
@@ -1,0 +1,32 @@
+## 0.6 -> 0.7
+
+With the pre-0.6 wrapper, you could start the agent and get the public URL like so:
+
+```rust
+    let tunnel = ngrok::builder()
+        .https()
+        .port(3030)
+        .run()?;
+
+    let public_url: url::Url = tunnel.public_url()?;
+```
+
+The new rust-native implementation supports similar connection-forwarding:
+```rust
+	let forwards_to = "localhost:3030";
+	let mut tunnel = ngrok::Session::builder()
+        .authtoken_from_env()
+        .connect()
+        .await?
+        .http_endpoint()
+        .forwards_to(forwards_to)
+        .listen()
+        .await?;
+
+	let public_url = tunnel.url();
+
+	tunnel.forward_http(forwards_to).await?;
+```
+
+See the [examples](https://github.com/ngrok/ngrok-rs/tree/main/ngrok/examples)
+for more way to use `ngrok`!


### PR DESCRIPTION
Still working on the upgrading guide.

We're going to start at v0.7.0 since the current `ngrok` crate on crates.io is at v0.6.0, and we don't want to break users. A minor version bump reflects a breaking change pre-1.0, so they won't accidentally switch from the wrapper to our new crate.