### PR TITLE
alias curl to cover uses inside install.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
-      - run: curl --retry 5 --retry-all-errors -sfL https://direnv.net/install.sh | bash
+      - run: alias curl="curl --retry 5 --retry-all-errors"
+      - run: curl https://direnv.net/install.sh | bash
       - run: direnv allow
       - run: direnv export gha >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
@@ -27,7 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
-      - run: curl --retry 5 --retry-all-errors -sfL https://direnv.net/install.sh | bash
+      - run: alias curl="curl --retry 5 --retry-all-errors"
+      - run: curl https://direnv.net/install.sh | bash
       - run: direnv allow
       - run: direnv export gha >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
@@ -41,7 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
-      - run: curl --retry 5 --retry-all-errors -sfL https://direnv.net/install.sh | bash
+      - run: alias curl="curl --retry 5 --retry-all-errors"
+      - run: curl https://direnv.net/install.sh | bash
       - run: direnv allow
       - run: direnv export gha >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
@@ -55,7 +58,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
-      - run: curl --retry 5 --retry-all-errors -sfL https://direnv.net/install.sh | bash
+      - run: alias curl="curl --retry 5 --retry-all-errors"
+      - run: curl https://direnv.net/install.sh | bash
       - run: direnv allow
       - run: direnv export gha >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
this seems to have gotten rid of the 403's from the curls inside the direnv install.sh script for me in another repo, if you want to give it a try.