### PR TITLE
add tokio "net" feature to support tunnel_ext for cargo users

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,11 @@
             fix-n-fmt
             setup-hooks
             cargo-udeps
-          ] ++ lib.optionals stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security ];
+          ] ++ lib.optionals stdenv.isDarwin [
+            # nix darwin stdenv has broken libiconv: https://github.com/NixOS/nixpkgs/issues/158331
+            libiconv
+            pkgs.darwin.apple_sdk.frameworks.Security
+          ];
         };
       });
 }

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 base64 = "0.13.1"
-tokio = { version = "1.23.0", features = ["sync", "time"] }
+tokio = { version = "1.23.0", features = ["net", "sync", "time"] }
 tracing = "0.1.37"
 async-rustls = { version = "0.3.0" }
 tokio-util = { version = "0.7.4", features = ["compat"] }

--- a/ngrok/src/tunnel.rs
+++ b/ngrok/src/tunnel.rs
@@ -320,7 +320,7 @@ make_tunnel_type! {
     TcpTunnel, TcpTunnelBuilder, url, proto
 }
 make_tunnel_type! {
-    /// An ngrok tunnel bcking a TLS endpoint.
+    /// An ngrok tunnel backing a TLS endpoint.
     TlsTunnel, TlsTunnelBuilder, url, proto
 }
 make_tunnel_type! {


### PR DESCRIPTION
`net: Enables tokio::net types such as TcpStream, UnixStream and UdpSocket, as well as (on Unix-like systems) AsyncFd and (on FreeBSD) PollAio.` https://docs.rs/tokio/latest/tokio/

Also add `libiconv` for darwin in nix, so don't have to use homebrew's.