### PR TITLE
handle non-camel-case in tls and tcp deserialization

### DIFF
--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -44,6 +44,7 @@ async fn start_tunnel() -> anyhow::Result<impl UrlTunnel> {
         // .compression()
         // .deny_cidr_string("10.1.1.1/32")
         // .domain("<somedomain>.ngrok.io")
+        // .forwards_to("example rust")
         // .mutual_tlsca(CA_CERT.into())
         // .oauth(
         //     OauthOptions::new("google")

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -62,7 +62,7 @@ impl FromStr for Scheme {
     type Err = InvalidSchemeString;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use Scheme::*;
-        Ok(match s {
+        Ok(match s.to_uppercase().as_str() {
             "HTTP" => HTTP,
             "HTTPS" => HTTPS,
             _ => return Err(InvalidSchemeString(s.into())),
@@ -315,7 +315,7 @@ mod test {
             .deny_cidr_string(DENY_CIDR)
             .proxy_proto(ProxyProto::V2)
             .metadata(METADATA)
-            .scheme(Scheme::HTTPS)
+            .scheme(Scheme::from_str("hTtPs").unwrap())
             .domain(DOMAIN)
             .mutual_tlsca(CA_CERT.into())
             .mutual_tlsca(CA_CERT2.into())

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -1,10 +1,14 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    str::FromStr,
+};
 
 use async_trait::async_trait;
 use bytes::{
     self,
     Bytes,
 };
+use thiserror::Error;
 
 use super::{
     common::ProxyProto,
@@ -37,6 +41,11 @@ use crate::{
     Session,
 };
 
+/// Error representing invalid string for Scheme
+#[derive(Debug, Clone, Error)]
+#[error("invalid scheme string: {}", .0)]
+pub struct InvalidSchemeString(String);
+
 /// The URL scheme for this HTTP endpoint.
 ///
 /// [Scheme::HTTPS] will enable TLS termination at the ngrok edge.
@@ -47,6 +56,18 @@ pub enum Scheme {
     /// The `https` URL scheme.
     #[default]
     HTTPS,
+}
+
+impl FromStr for Scheme {
+    type Err = InvalidSchemeString;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use Scheme::*;
+        Ok(match s {
+            "HTTP" => HTTP,
+            "HTTPS" => HTTPS,
+            _ => return Err(InvalidSchemeString(s.into())),
+        })
+    }
 }
 
 /// The options for a HTTP edge.

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -642,6 +642,7 @@ pub struct WebhookVerification {
 pub struct MutualTls {
     #[serde(default, skip_serializing_if = "is_default")]
     #[serde(with = "base64bytes")]
+    // this is snake-case on the wire
     pub mutual_tls_ca: Vec<u8>,
 }
 
@@ -664,7 +665,7 @@ pub struct WebsocketTcpConverter {}
 pub struct TcpEndpoint {
     pub addr: String,
     pub proxy_proto: ProxyProto,
-
+    #[serde(rename = "IPRestriction")]
     pub ip_restriction: Option<IpRestriction>,
 }
 
@@ -674,10 +675,14 @@ pub struct TlsEndpoint {
     pub hostname: String,
     pub subdomain: String,
     pub proxy_proto: ProxyProto,
+    #[serde(rename = "MutualTLSAtAgent")]
     pub mutual_tls_at_agent: bool,
 
+    #[serde(rename = "MutualTLSAtEdge")]
     pub mutual_tls_at_edge: Option<MutualTls>,
+    #[serde(rename = "TLSTermination")]
     pub tls_termination: Option<TlsTermination>,
+    #[serde(rename = "IPRestriction")]
     pub ip_restriction: Option<IpRestriction>,
 }
 
@@ -685,7 +690,7 @@ pub struct TlsEndpoint {
 pub struct TlsTermination {
     #[serde(with = "base64bytes", skip_serializing_if = "is_default")]
     pub cert: Vec<u8>,
-    #[serde(skip_serializing_if = "is_default")]
+    #[serde(skip_serializing_if = "is_default", default)]
     pub key: SecretBytes,
     #[serde(with = "base64bytes", skip_serializing_if = "is_default")]
     pub sealed_key: Vec<u8>,


### PR DESCRIPTION
Also adds a tls online test, `Scheme::from_str`, and a `forwards_to` example.