### PR TITLE
ci: cache nix dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v18
-      - uses: jrobsonchase/direnv-action@v0.6
+      - uses: jrobsonchase/direnv-action@v0.7
       - uses: actions-rs/cargo@v1
         with:
           command: udeps
@@ -24,8 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v18
-      - uses: jrobsonchase/direnv-action@v0.6
+      - uses: jrobsonchase/direnv-action@v0.7
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -36,8 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v18
-      - uses: jrobsonchase/direnv-action@v0.6
+      - uses: jrobsonchase/direnv-action@v0.7
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -48,8 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v18
-      - uses: jrobsonchase/direnv-action@v0.6
+      - uses: jrobsonchase/direnv-action@v0.7
       - uses: actions-rs/cargo@v1
         env:
           NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
@@ -82,8 +78,7 @@ jobs:
         crate: [muxado, ngrok]
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v18
-      - uses: jrobsonchase/direnv-action@v0.6
+      - uses: jrobsonchase/direnv-action@v0.7
       - uses: actions-rs/cargo@v1
         name: semver checks
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v18
-      - uses: jrobsonchase/direnv-action@v0.6
+      - uses: jrobsonchase/direnv-action@v0.7
       - name: cargo publish
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Bumping my direnv action to 0.7, which now includes nix installation and direnv cache/import/export. Might hopefully speed things along a little bit, since we'll be fetching a single big archive from github rather than lots of little ones from the nixos cache.