### PR TITLE
ngrok: add support for dashboard command handlers

### DIFF
--- a/muxado/src/typed.rs
+++ b/muxado/src/typed.rs
@@ -18,6 +18,7 @@ use tokio::io::{
     AsyncReadExt,
     AsyncWriteExt,
 };
+use tracing::debug;
 
 use crate::{
     constrained::*,
@@ -136,6 +137,8 @@ where
             .map_err(|_| Error::StreamClosed)?;
 
         let typ = StreamType::clamp((&buf[..]).get_u32());
+
+        debug!(?typ, "read stream type");
 
         Ok(TypedStream { typ, inner: stream })
     }

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/examples/mingrok.rs
+++ b/ngrok/examples/mingrok.rs
@@ -1,5 +1,15 @@
+use std::sync::{
+    Arc,
+    Mutex,
+};
+
 use anyhow::Error;
+use futures::{
+    prelude::*,
+    select,
+};
 use ngrok::prelude::*;
+use tokio::sync::oneshot;
 use tracing::info;
 
 #[tokio::main]
@@ -13,21 +23,62 @@ async fn main() -> Result<(), Error> {
         .nth(1)
         .ok_or_else(|| anyhow::anyhow!("missing forwarding address"))?;
 
-    let mut tun = ngrok::Session::builder()
-        .authtoken_from_env()
-        .connect()
-        .await?
-        .http_endpoint()
-        .forwards_to(&forwards_to)
-        .listen()
-        .await?;
+    loop {
+        let (stop_tx, stop_rx) = oneshot::channel();
+        let stop_tx = Arc::new(Mutex::new(Some(stop_tx)));
 
-    info!(url = tun.url(), forwards_to, "started tunnel");
+        let (restart_tx, restart_rx) = oneshot::channel();
+        let restart_tx = Arc::new(Mutex::new(Some(restart_tx)));
 
-    let fut = if forwards_to.contains('/') {
-        tun.forward_unix(forwards_to)
-    } else {
-        tun.forward_http(forwards_to)
-    };
-    Ok(fut.await?)
+        let mut tun = ngrok::Session::builder()
+            .authtoken_from_env()
+            .handle_stop_command(move |req| {
+                let stop_tx = stop_tx.clone();
+                async move {
+                    info!(?req, "received stop command");
+                    let _ = stop_tx.lock().unwrap().take().unwrap().send(());
+                    Ok(())
+                }
+            })
+            .handle_restart_command(move |req| {
+                let restart_tx = restart_tx.clone();
+                async move {
+                    info!(?req, "received restart command");
+                    let _ = restart_tx.lock().unwrap().take().unwrap().send(());
+                    Ok(())
+                }
+            })
+            .handle_update_command(|req| async move {
+                info!(?req, "received update command");
+                Err("unable to update".into())
+            })
+            .connect()
+            .await?
+            .http_endpoint()
+            .forwards_to(&forwards_to)
+            .listen()
+            .await?;
+
+        info!(url = tun.url(), forwards_to, "started tunnel");
+
+        let mut fut = if forwards_to.contains('/') {
+            tun.forward_unix(&forwards_to)
+        } else {
+            tun.forward_http(&forwards_to)
+        }
+        .fuse();
+
+        let mut stop_rx = stop_rx.fuse();
+        let mut restart_rx = restart_rx.fuse();
+
+        select! {
+            res = fut => return Ok(res?),
+            _ = stop_rx => return Ok(()),
+            _ = restart_rx => {
+                drop(fut);
+                let _ = tun.close().await;
+                continue
+            },
+        }
+    }
 }

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -231,22 +231,22 @@ impl HttpTunnelBuilder {
         self
     }
 
-    /// with_request_header adds a header to all requests to this edge.
+    /// request_header adds a header to all requests to this edge.
     pub fn request_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.options.request_headers.add(name, value);
         self
     }
-    /// with_response_header adds a header to all responses coming from this edge.
+    /// response_header adds a header to all responses coming from this edge.
     pub fn response_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.options.response_headers.add(name, value);
         self
     }
-    /// with_remove_request_header removes a header from requests to this edge.
+    /// remove_request_header removes a header from requests to this edge.
     pub fn remove_request_header(mut self, name: impl Into<String>) -> Self {
         self.options.request_headers.remove(name);
         self
     }
-    /// with_remove_response_header removes a header from responses from this edge.
+    /// remove_response_header removes a header from responses from this edge.
     pub fn remove_response_header(mut self, name: impl Into<String>) -> Self {
         self.options.response_headers.remove(name);
         self

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -382,37 +382,44 @@ impl<'de> Deserialize<'de> for EdgeType {
     }
 }
 
+/// A request from the ngrok dashboard for the agent to stop.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
 #[serde(rename_all = "PascalCase")]
-pub struct Stop;
+pub struct Stop {}
 
+/// Common response structure for all remote commands originating from the ngrok
+/// dashboard.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "PascalCase")]
-pub struct StopResp {}
+pub struct CommandResp {
+    /// The error arising from command handling, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+pub type StopResp = CommandResp;
 
 rpc_req!(Stop, StopResp, STOP_REQ);
 
+/// A request from the ngrok dashboard for the agent to restart.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
 #[serde(rename_all = "PascalCase")]
-pub struct Restart;
+pub struct Restart {}
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "PascalCase")]
-pub struct RestartResp {}
-
+pub type RestartResp = CommandResp;
 rpc_req!(Restart, RestartResp, RESTART_REQ);
 
+/// A request from the ngrok dashboard for the agent to update itself.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct Update {
+    /// The version that the agent is requested to update to.
     pub version: String,
+    /// Whether or not updating to the same major version is sufficient.
     pub permit_major_version: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "PascalCase")]
-pub struct UpdateResp {}
-
+pub type UpdateResp = CommandResp;
 rpc_req!(Update, UpdateResp, UPDATE_REQ);
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]


### PR DESCRIPTION
Not 100% happy with the `Fn` rather than `FnMut` constraint, but we can
probably loosen that later if it becomes too much of an issue.

I'm not sure if the fields to the update command actually get sent, or
if they're just some old meaningless cruft that we don't actually use
anymore.

Still need to do the local connection state callbacks, but I think those
are separate enough to warrant a different PR.

As an aside, I also noticed that the session/tunnels don't stop if there are
no reachable handles to them in consumer code. Like in the `mingrok`
example, both the session and tunnel stick around after a restart, and
even if you close the tunnel, the session is *still* hanging out. Going
to file a bug for that - probably something missed in the restart logic,
if not deeper.
