### PR TITLE
muxado: cancel tasks when all references are dropped

### DIFF
--- a/muxado/Cargo.toml
+++ b/muxado/Cargo.toml
@@ -18,6 +18,7 @@ pin-project = "1.0.12"
 tracing = "0.1.37"
 async-trait = "0.1.59"
 rand = "0.8.5"
+awaitdrop = "0.1.1"
 
 [dev-dependencies]
 anyhow = { version = "1.0.66" }

--- a/muxado/src/cancellation_test.rs
+++ b/muxado/src/cancellation_test.rs
@@ -19,10 +19,8 @@ async fn test_cancellation() -> Result<(), Box<dyn Error>> {
 
     let (dropref, waiter) = awaitdrop::awaitdrop();
 
-    let mut server = info_span!("muxado", side = "server").in_scope(move || {
-        tracing::info!("foo");
-        SessionBuilder::new(left).server().start()
-    });
+    let mut server = info_span!("muxado", side = "server")
+        .in_scope(move || SessionBuilder::new(left).server().start());
     let mut client = info_span!("muxado", side = "client")
         .in_scope(|| SessionBuilder::new(right).client().start());
 

--- a/muxado/src/cancellation_test.rs
+++ b/muxado/src/cancellation_test.rs
@@ -1,0 +1,50 @@
+use std::{
+    error::Error,
+    time::Duration,
+};
+
+use tokio::{
+    io::AsyncWriteExt,
+    test,
+};
+use tracing::info_span;
+use tracing_test::traced_test;
+
+use crate::*;
+
+#[traced_test]
+#[test]
+async fn test_cancellation() -> Result<(), Box<dyn Error>> {
+    let (left, right) = tokio::io::duplex(256);
+
+    let (dropref, waiter) = awaitdrop::awaitdrop();
+
+    let mut server = info_span!("muxado", side = "server").in_scope(move || {
+        tracing::info!("foo");
+        SessionBuilder::new(left).server().start()
+    });
+    let mut client = info_span!("muxado", side = "client")
+        .in_scope(|| SessionBuilder::new(right).client().start());
+
+    tokio::spawn(async move {
+        let mut streams = vec![];
+        while let Some(stream) = server.accept().await {
+            streams.push(stream);
+        }
+
+        drop(dropref);
+    });
+
+    let mut stream1 = client.open().await?;
+    let mut stream2 = client.open().await?;
+
+    stream1.write_all("Hello,".as_bytes()).await?;
+    stream2.write_all("World!".as_bytes()).await?;
+
+    drop(stream1);
+    drop(stream2);
+    drop(client);
+
+    tokio::time::timeout(Duration::from_secs(5), waiter.wait()).await?;
+    Ok(())
+}

--- a/muxado/src/heartbeat.rs
+++ b/muxado/src/heartbeat.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures::FutureExt;
+use futures::prelude::*;
 use tokio::{
     io::{
         AsyncReadExt,

--- a/muxado/src/lib.rs
+++ b/muxado/src/lib.rs
@@ -20,3 +20,6 @@ pub use session::*;
 pub use stream::Stream;
 
 pub mod heartbeat;
+
+#[cfg(test)]
+mod cancellation_test;

--- a/muxado/src/stream.rs
+++ b/muxado/src/stream.rs
@@ -44,6 +44,8 @@ use crate::{
 /// session.
 #[pin_project(project = StreamProj, PinnedDrop)]
 pub struct Stream {
+    pub(crate) dropref: Option<awaitdrop::Ref>,
+
     window: Window,
 
     read_buf: BytesMut,
@@ -87,6 +89,7 @@ impl Stream {
         needs_syn: bool,
     ) -> Self {
         Self {
+            dropref: None,
             window: Window::new(window_size),
             fin,
             fout,

--- a/muxado/src/stream_manager.rs
+++ b/muxado/src/stream_manager.rs
@@ -163,6 +163,9 @@ impl FusedStream for SharedStreamManager {
     }
 }
 
+// Stream implementation for StreamManager
+// This is used as the "output" from all of the streams and will produce frames
+// that need to be sent to the remote via the underlying IO stream.
 impl StreamT for StreamManager {
     type Item = Frame;
 
@@ -180,6 +183,7 @@ impl StreamT for StreamManager {
 
         // Handle system frames first, but don't return if it's not ready, or
         // it's somehow closed (shouldn't happen).
+        // TODO: handle locally-generated GOAWAYs by closing all streams, etc.
         if let Poll::Ready(Some(frame)) = self.as_mut().sys_rx().poll_next(cx) {
             return Some(frame).into();
         }


### PR DESCRIPTION
Created a fancy-pants waitgroup implementation just for this purpose. I expect to make a similar change to the ngrok crate to shut down its background tasks as well once all tunnels and the session is dropped.