### PR TITLE
ngrok/muxado: add a user-definable heartbeat handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 name: Continuous integration
 

--- a/muxado/CHANGELOG.md
+++ b/muxado/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+* Rework the heartbeat callback into a handler trait object.
+
 ## 0.2.0
 
 * `Heartbeat` no longer `(Ref)?UnwindSafe`. Technically a breaking change,

--- a/muxado/Cargo.toml
+++ b/muxado/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muxado"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The muxado stream multiplexing protocol"

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -7,7 +7,7 @@ description = "The ngrok agent SDK"
 repository = "https://github.com/ngrok/ngrok-rs"
 
 [dependencies]
-muxado = { path = "../muxado", version = "0.2" }
+muxado = { path = "../muxado", version = "0.3" }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"

--- a/ngrok/src/internals/raw_session.rs
+++ b/ngrok/src/internals/raw_session.rs
@@ -8,7 +8,6 @@ use std::{
         DerefMut,
     },
     sync::Arc,
-    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -167,14 +166,13 @@ pub struct CommandHandlers {
 }
 
 impl RawSession {
-    pub async fn start<S, F, H>(
+    pub async fn start<S, H>(
         io_stream: S,
-        heartbeat: HeartbeatConfig<F>,
+        heartbeat: HeartbeatConfig,
         handlers: H,
     ) -> Result<Self, StartSessionError>
     where
         S: AsyncRead + AsyncWrite + Send + 'static,
-        F: FnMut(Duration) + Send + 'static,
         H: Into<Option<CommandHandlers>>,
     {
         let mux_sess = SessionBuilder::new(io_stream).start();

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -17,7 +17,10 @@ use futures::{
     future::BoxFuture,
     FutureExt,
 };
-use muxado::heartbeat::HeartbeatConfig;
+use muxado::heartbeat::{
+    HeartbeatConfig,
+    HeartbeatHandler,
+};
 use rustls_pemfile::Item;
 use thiserror::Error;
 use tokio::{
@@ -178,6 +181,7 @@ pub struct SessionBuilder {
     metadata: Option<String>,
     heartbeat_interval: Option<Duration>,
     heartbeat_tolerance: Option<Duration>,
+    heartbeat_handler: Option<Arc<dyn HeartbeatHandler>>,
     server_addr: String,
     tls_config: rustls::ClientConfig,
     connector: ConnectFn,
@@ -254,6 +258,7 @@ impl Default for SessionBuilder {
             metadata: None,
             heartbeat_interval: None,
             heartbeat_tolerance: None,
+            heartbeat_handler: None,
             server_addr: "tunnel.ngrok.com:443".into(),
             tls_config,
             connector: default_connect(),
@@ -403,6 +408,15 @@ impl SessionBuilder {
         self
     }
 
+    /// Call the provided handler whenever a heartbeat response is received.
+    ///
+    /// If the handler returns an error, the heartbeat task will exit, resulting
+    /// in the session eventually dying as well.
+    pub fn handle_heartbeat(mut self, callback: impl HeartbeatHandler) -> Self {
+        self.heartbeat_handler = Some(Arc::new(callback));
+        self
+    }
+
     /// Begins a new ngrok [Session] by connecting to the ngrok service.
     /// `connect` blocks until the session is successfully established or fails with
     /// an error.
@@ -424,13 +438,14 @@ impl SessionBuilder {
         let conn =
             (self.connector)(self.server_addr.clone(), Arc::new(self.tls_config.clone())).await?;
 
-        let mut heartbeat_config = HeartbeatConfig::<fn(Duration)>::default();
+        let mut heartbeat_config = HeartbeatConfig::default();
         if let Some(interval) = self.heartbeat_interval {
             heartbeat_config.interval = interval;
         }
         if let Some(tolerance) = self.heartbeat_tolerance {
             heartbeat_config.tolerance = tolerance;
         }
+        heartbeat_config.handler = self.heartbeat_handler.clone();
         // convert these while we have ownership
         let interval_nanos = heartbeat_config.interval.as_nanos();
         let heartbeat_interval = i64::try_from(interval_nanos)


### PR DESCRIPTION
~~Not entirely happy with the mutex here. Might drop it back to non-mut/`Fn` rather than `&mut`/`FnMut`. It's fine for the single-restarting-session case, but cloning the builder and starting multiple concurrent sessions with it could cause problems since they'd be fighting to lock the handler.~~ No more mutex!

Consumers will have to deal with interior mutability themselves, but that seems fine-ish. It at least matches the command handlers.