### PR TITLE
ngrok: detect tunnel/session liveness and shutdown background tasks

### DIFF
--- a/cargo-doc-ngrok/Cargo.toml
+++ b/cargo-doc-ngrok/Cargo.toml
@@ -14,6 +14,6 @@ futures = "0.3.25"
 http = "0.2.8"
 hyper = { version = "0.14.23", features = ["server"] }
 hyper-staticfile = "0.9.2"
-ngrok = { path = "../ngrok", version = "0.8.0", features = ["hyper"] }
+ngrok = { path = "../ngrok", version = "0.8", features = ["hyper"] }
 tokio = { version = "1.23.0", features = ["full"] }
 watchexec = "2.0.2"

--- a/muxado/CHANGELOG.md
+++ b/muxado/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.2.0
+
+* `Heartbeat` no longer `(Ref)?UnwindSafe`. Technically a breaking change,
+therefore bumping its minor version.
+
+
+## 0.1.0
+
+* Initial Public Release

--- a/muxado/Cargo.toml
+++ b/muxado/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muxado"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The muxado stream multiplexing protocol"

--- a/muxado/src/heartbeat.rs
+++ b/muxado/src/heartbeat.rs
@@ -18,7 +18,10 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures::prelude::*;
+use futures::{
+    future::select,
+    prelude::*,
+};
 use tokio::{
     io::{
         AsyncReadExt,
@@ -47,6 +50,7 @@ const HEARTBEAT_TYPE: StreamType = StreamType::clamp(0xFFFFFFFF);
 /// Wrapper for a muxado [TypedSession] that adds heartbeating over a dedicated
 /// typed stream.
 pub struct Heartbeat<S> {
+    dropped: awaitdrop::Waiter,
     typ: StreamType,
     inner: S,
 }
@@ -54,8 +58,11 @@ pub struct Heartbeat<S> {
 /// Controller for the heartbeat task.
 ///
 /// Allows owners to change the heartbeat timing at runtime and to explicitly
-/// request heartbeats.
+/// request heartbeats. When dropped, cancels the heartbeat tasks.
 pub struct HeartbeatCtl {
+    // Implicitly used to cancel the heartbeat tasks.
+    #[allow(dead_code)]
+    dropref: awaitdrop::Ref,
     durations: Arc<(AtomicU64, AtomicU64)>,
     on_demand: mpsc::Sender<oneshot::Sender<Duration>>,
 }
@@ -94,7 +101,10 @@ where
     where
         F: FnMut(Duration) + Send + 'static,
     {
+        let (dropref, dropped) = awaitdrop::awaitdrop();
+
         let mut hb = Heartbeat {
+            dropped: dropped.clone(),
             typ: HEARTBEAT_TYPE,
             inner: sess,
         };
@@ -102,6 +112,7 @@ where
         let (dtx, drx) = mpsc::channel(1);
         let (mtx, mrx) = mpsc::channel(1);
         let mut ctl = HeartbeatCtl {
+            dropref,
             durations: Arc::new((
                 (cfg.interval.as_nanos() as u64).into(),
                 (cfg.tolerance.as_nanos() as u64).into(),
@@ -115,8 +126,9 @@ where
             .await
             .map_err(|_| io::ErrorKind::ConnectionReset)?;
 
-        ctl.start_requester(stream, drx, mtx).await?;
-        ctl.start_check(mrx, cfg.callback)?;
+        ctl.start_requester(stream, drx, mtx, dropped.wait())
+            .await?;
+        ctl.start_check(mrx, cfg.callback, dropped.wait())?;
 
         Ok((hb, ctl))
     }
@@ -151,6 +163,7 @@ impl HeartbeatCtl {
         &mut self,
         mut mark: mpsc::Receiver<Duration>,
         mut cb: Option<F>,
+        dropped: awaitdrop::WaitFuture,
     ) -> Result<(), io::Error>
     where
         F: FnMut(Duration) + Send + 'static,
@@ -159,35 +172,39 @@ impl HeartbeatCtl {
         let durations = self.durations.clone();
 
         tokio::spawn(
-            async move {
-                let mut deadline = tokio::time::Instant::now() + interval + tolerance;
-                loop {
-                    match tokio::time::timeout_at(deadline, mark.recv()).await {
-                        Err(_e) => {
-                            if let Some(cb) = cb.as_mut() {
-                                cb(Duration::from_secs(0))
+            select(
+                async move {
+                    let mut deadline = tokio::time::Instant::now() + interval + tolerance;
+                    loop {
+                        match tokio::time::timeout_at(deadline, mark.recv()).await {
+                            Err(_e) => {
+                                if let Some(cb) = cb.as_mut() {
+                                    cb(Duration::from_secs(0))
+                                }
                             }
-                        }
-                        Ok(Some(lat)) => {
-                            if let Some(cb) = cb.as_mut() {
-                                cb(lat)
+                            Ok(Some(lat)) => {
+                                if let Some(cb) = cb.as_mut() {
+                                    cb(lat)
+                                }
                             }
-                        }
-                        Ok(None) => {
-                            return;
-                        }
-                    };
+                            Ok(None) => {
+                                return;
+                            }
+                        };
 
-                    // Slight divergence from Go implementation: this didn't
-                    // previously happen in the "timeout" case, which did noting but
-                    // the callback. Presumably, this usually killed the connection,
-                    // causing the goroutine to exit *anyway*. If we didn't reset
-                    // the deadline here, it would timeout immediately rather than
-                    // blocking indefinitely as in Go.
-                    (interval, tolerance) = get_durations(&durations);
-                    deadline = tokio::time::Instant::now() + interval + tolerance;
+                        // Slight divergence from Go implementation: this didn't
+                        // previously happen in the "timeout" case, which did noting but
+                        // the callback. Presumably, this usually killed the connection,
+                        // causing the goroutine to exit *anyway*. If we didn't reset
+                        // the deadline here, it would timeout immediately rather than
+                        // blocking indefinitely as in Go.
+                        (interval, tolerance) = get_durations(&durations);
+                        deadline = tokio::time::Instant::now() + interval + tolerance;
+                    }
                 }
-            }
+                .boxed(),
+                dropped,
+            )
             .then(|_| async move {
                 tracing::debug!("check exited");
             }),
@@ -201,61 +218,66 @@ impl HeartbeatCtl {
         mut stream: TypedStream,
         mut on_demand: mpsc::Receiver<oneshot::Sender<Duration>>,
         mark: mpsc::Sender<Duration>,
+        dropped: awaitdrop::WaitFuture,
     ) -> Result<(), io::Error> {
         let (interval, _) = self.get_durations();
         let mut ticker = tokio::time::interval(interval);
 
         tokio::spawn(
-            async move {
-                loop {
-                    let mut resp_chan: Option<oneshot::Sender<Duration>> = None;
+            select(
+                async move {
+                    loop {
+                        let mut resp_chan: Option<oneshot::Sender<Duration>> = None;
 
-                    select! {
-                        // If on_demand is closed, this will return None
-                        // immediately. In that case, wait on the next tick instead.
-                        c = on_demand.recv() => if c.is_none() {
-                            ticker.tick().await;
+                        select! {
+                            // If on_demand is closed, this will return None
+                            // immediately. In that case, wait on the next tick instead.
+                            c = on_demand.recv() => if c.is_none() {
+                                ticker.tick().await;
+                            } else {
+                                resp_chan = c;
+                            },
+                            _ = ticker.tick() => {},
+                        }
+
+                        tracing::debug!("sending heartbeat");
+
+                        let start = std::time::Instant::now();
+                        let id: i32 = rand::random();
+
+                        if stream.write_all(&id.to_be_bytes()[..]).await.is_err() {
+                            return;
+                        }
+
+                        let mut resp_bytes = [0u8; 4];
+
+                        tracing::debug!("waiting for response");
+
+                        if stream.read_exact(&mut resp_bytes[..]).await.is_err() {
+                            tracing::debug!("error reading response");
+                            return;
+                        }
+
+                        tracing::debug!("got response");
+
+                        let resp_id = i32::from_be_bytes(resp_bytes);
+
+                        if id != resp_id {
+                            return;
+                        }
+
+                        let latency = std::time::Instant::now() - start;
+
+                        if let Some(resp_chan) = resp_chan {
+                            let _ = resp_chan.send(latency);
                         } else {
-                            resp_chan = c;
-                        },
-                        _ = ticker.tick() => {},
-                    }
-
-                    tracing::debug!("sending heartbeat");
-
-                    let start = std::time::Instant::now();
-                    let id: i32 = rand::random();
-
-                    if stream.write_all(&id.to_be_bytes()[..]).await.is_err() {
-                        return;
-                    }
-
-                    let mut resp_bytes = [0u8; 4];
-
-                    tracing::debug!("waiting for response");
-
-                    if stream.read_exact(&mut resp_bytes[..]).await.is_err() {
-                        tracing::debug!("error reading response");
-                        return;
-                    }
-
-                    tracing::debug!("got response");
-
-                    let resp_id = i32::from_be_bytes(resp_bytes);
-
-                    if id != resp_id {
-                        return;
-                    }
-
-                    let latency = std::time::Instant::now() - start;
-
-                    if let Some(resp_chan) = resp_chan {
-                        let _ = resp_chan.send(latency);
-                    } else {
-                        let _ = mark.send(latency).await;
+                            let _ = mark.send(latency).await;
+                        }
                     }
                 }
-            }
+                .boxed(),
+                dropped,
+            )
             .then(|_| async move {
                 tracing::debug!("requester exited");
             }),
@@ -269,20 +291,24 @@ impl HeartbeatCtl {
     }
 }
 
-fn start_responder(mut stream: TypedStream) {
-    tokio::spawn(async move {
-        loop {
-            let mut buf = [0u8; 4];
-            if let Err(e) = stream.read(&mut buf[..]).await {
-                tracing::debug!(?e, "heartbeat responder exiting");
-                return;
-            }
-            if let Err(e) = stream.write_all(&buf[..]).await {
-                tracing::debug!(?e, "heartbeat responder exiting");
-                return;
+fn start_responder(mut stream: TypedStream, dropped: awaitdrop::WaitFuture) {
+    tokio::spawn(select(
+        async move {
+            loop {
+                let mut buf = [0u8; 4];
+                if let Err(e) = stream.read(&mut buf[..]).await {
+                    tracing::debug!(?e, "heartbeat responder exiting");
+                    return;
+                }
+                if let Err(e) = stream.write_all(&buf[..]).await {
+                    tracing::debug!(?e, "heartbeat responder exiting");
+                    return;
+                }
             }
         }
-    });
+        .boxed(),
+        dropped,
+    ));
 }
 
 #[async_trait]
@@ -296,7 +322,7 @@ where
             let typ = stream.typ();
 
             if typ == self.typ {
-                start_responder(stream);
+                start_responder(stream, self.dropped.wait());
                 continue;
             }
 
@@ -330,11 +356,20 @@ where
     type TypedOpen = Heartbeat<S::TypedOpen>;
 
     fn split_typed(self) -> (Self::TypedOpen, Self::TypedAccept) {
+        let dropped = self.dropped;
         let typ = self.typ;
         let (open, accept) = self.inner.split_typed();
         (
-            Heartbeat { typ, inner: open },
-            Heartbeat { typ, inner: accept },
+            Heartbeat {
+                dropped: dropped.clone(),
+                typ,
+                inner: open,
+            },
+            Heartbeat {
+                dropped,
+                typ,
+                inner: accept,
+            },
         )
     }
 }

--- a/ngrok/CHANGELOG.md
+++ b/ngrok/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.1
+
+* Fix cancellation bugs causing leaked muxado/ngrok sessions.
+
+## 0.8.0
+
+* Some breaking changes to builder method naming for consistency.
+* Add dashboard command handlers
 
 ## 0.7.0
 

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ngrok"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"
 repository = "https://github.com/ngrok/ngrok-rs"
 
 [dependencies]
-muxado = { path = "../muxado", version = "0.1.1" }
+muxado = { path = "../muxado", version = "0.1" }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -7,7 +7,7 @@ description = "The ngrok agent SDK"
 repository = "https://github.com/ngrok/ngrok-rs"
 
 [dependencies]
-muxado = { path = "../muxado", version = "0.1" }
+muxado = { path = "../muxado", version = "0.2" }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = "0.1.59"
 bytes = "1.3.0"
 arc-swap = "1.5.1"
 tokio-retry = "0.3.0"
+awaitdrop = "0.1.1"
 
 [dev-dependencies]
 tokio = { version = "1.23.0", features = ["full"] }

--- a/ngrok/src/tunnel.rs
+++ b/ngrok/src/tunnel.rs
@@ -51,8 +51,13 @@ pub(crate) struct TunnelInner {
     pub(crate) labels: HashMap<String, String>,
     pub(crate) forwards_to: String,
     pub(crate) metadata: String,
-    pub(crate) session: Session,
     pub(crate) incoming: Receiver<Result<Conn, AcceptError>>,
+
+    // Note: this session field is also used to detect tunnel liveness for the
+    // purposes of shutting down the accept loop. If it's ever removed, an
+    // awaitdrop::Ref field needs to be added that's derived from the one
+    // belonging to the session.
+    pub(crate) session: Session,
 }
 
 // This codgen indirect is required to make the hyper "Accept" trait bound


### PR DESCRIPTION
Basically the same change as muxado cancellation.

Tunnels already having a reference to the session ended up being really
convenient.

Resolves #57 