### PR TITLE
add windows pipe support

### DIFF
--- a/cargo-doc-ngrok/Cargo.toml
+++ b/cargo-doc-ngrok/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/ngrok/ngrok-rs"
 
 [dependencies]
 axum = "0.6.1"
+# use older bstr until watchexec::ignore-files switches from git-config 0.14.0 to gix-config 0.16.2 (PR 502)
+bstr = "=1.0.1"
 cargo_metadata = "0.15.2"
 clap = { version = "4.0.29", features = ["derive"] }
 futures = "0.3.25"

--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,7 @@
           ] ++ lib.optionals stdenv.isDarwin [
             # nix darwin stdenv has broken libiconv: https://github.com/NixOS/nixpkgs/issues/158331
             libiconv
+            pkgs.darwin.apple_sdk.frameworks.CoreServices
             pkgs.darwin.apple_sdk.frameworks.Security
           ];
         };

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -27,6 +27,9 @@ tokio-retry = "0.3.0"
 awaitdrop = "0.1.1"
 parking_lot = "0.12.1"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = "0.45.0"
+
 [dev-dependencies]
 tokio = { version = "1.23.0", features = ["full"] }
 anyhow = "1.0.66"

--- a/ngrok/examples/mingrok.rs
+++ b/ngrok/examples/mingrok.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Error> {
         info!(url = tun.url(), forwards_to, "started tunnel");
 
         let mut fut = if forwards_to.contains('/') {
-            tun.forward_unix(&forwards_to)
+            tun.forward_pipe(&forwards_to)
         } else {
             tun.forward_http(&forwards_to)
         }


### PR DESCRIPTION
Allows using named pipes on windows, e.g. `\\.\pipe\ngrok_pipe`