### PR TITLE
ngrok: add support for "child" client types/versions

### DIFF
--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -542,10 +542,10 @@ impl SessionBuilder {
         let mut version = VERSION.to_string();
 
         for (child_type, child_version) in &self.versions {
-            client_type.push_str(",");
-            client_type.push_str(&child_type);
-            version.push_str(",");
-            version.push_str(&child_version);
+            client_type.push(',');
+            client_type.push_str(child_type);
+            version.push(',');
+            version.push_str(child_version);
         }
 
         let resp = raw


### PR DESCRIPTION
Kinda rough/subject to change in the future, but at least it'll give us
a way to "stack" abstraction types and versions, like js, the agent,
etc.

The protocol semantics are almost certain to get an overhaul once we
figure out the "minimum version enforcement" feature, but for now, this
seems "good enough."
