### PR TITLE
Add OauthProvider Enum to OauthOptions

### DIFF
--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -290,6 +290,7 @@ impl HttpTunnelBuilder {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::config::OauthProvider;
 
     const METADATA: &str = "testmeta";
     const TEST_FORWARD: &str = "testforward";
@@ -323,9 +324,9 @@ mod test {
             .response_header("X-Res-Yup", "true")
             .remove_request_header("X-Req-Nope")
             .remove_response_header("X-Res-Nope")
-            .oauth(OauthOptions::new("google"))
+            .oauth(OauthOptions::new(OauthProvider::Google))
             .oauth(
-                OauthOptions::new("google")
+                OauthOptions::new(OauthProvider::Google)
                     .allow_email("<user>@<domain>")
                     .allow_domain("<domain>")
                     .scope("<scope>"),

--- a/ngrok/src/config/oauth.rs
+++ b/ngrok/src/config/oauth.rs
@@ -1,13 +1,15 @@
+use std::fmt::Display;
+
 use crate::internals::proto::{
     Oauth,
     SecretString,
 };
 
 /// Oauth Options configuration
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct OauthOptions {
     /// The OAuth provider to use
-    provider: String,
+    provider: OauthProvider,
 
     /// The client ID, if a custom one is being used
     client_id: String,
@@ -24,10 +26,14 @@ pub struct OauthOptions {
 
 impl OauthOptions {
     /// Create a new [OauthOptions] for the given provider.
-    pub fn new(provider: impl Into<String>) -> Self {
+    pub fn new(provider: OauthProvider) -> Self {
         OauthOptions {
-            provider: provider.into(),
-            ..Default::default()
+            provider,
+            client_id: String::default(),
+            client_secret: SecretString::default(),
+            allow_emails: Vec::default(),
+            allow_domains: Vec::default(),
+            scopes: Vec::default(),
         }
     }
 
@@ -64,7 +70,7 @@ impl OauthOptions {
 impl From<OauthOptions> for Oauth {
     fn from(o: OauthOptions) -> Self {
         Oauth {
-            provider: o.provider,
+            provider: o.provider.to_string(),
             client_id: o.client_id,
             client_secret: o.client_secret,
             sealed_client_secret: Default::default(), // unused in this context
@@ -72,5 +78,37 @@ impl From<OauthOptions> for Oauth {
             allow_domains: o.allow_domains,
             scopes: o.scopes,
         }
+    }
+}
+
+/// OAuth provider to be used with OauthOptions
+#[derive(Clone)]
+pub enum OauthProvider {
+    Amazon,
+    Facebook,
+    GitHub,
+    GitLab,
+    Google,
+    LinkedIn,
+    Microsoft,
+    Twitch,
+}
+
+impl Display for OauthProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                OauthProvider::Amazon => "amazon",
+                OauthProvider::Facebook => "facebook",
+                OauthProvider::GitHub => "github",
+                OauthProvider::GitLab => "gitlab",
+                OauthProvider::Google => "google",
+                OauthProvider::LinkedIn => "linkedin",
+                OauthProvider::Microsoft => "microsoft",
+                OauthProvider::Twitch => "twitch",
+            }
+        )
     }
 }


### PR DESCRIPTION
I thought it would be more intuitive if `OauthOptions::new()` accepted an enum to ensure the value is checked at compile time rather than raising an error for invalid input at run time.

The `Oauth.provider` field could also be made an `OauthProvider` instead of a `String` but I didn't want to be too disruptive with this PR. 
