### PR TITLE
Add comment to client_info

### DIFF
--- a/cargo-doc-ngrok/Cargo.toml
+++ b/cargo-doc-ngrok/Cargo.toml
@@ -15,6 +15,6 @@ futures = "0.3.25"
 http = "0.2.8"
 hyper = { version = "0.14.23", features = ["server"] }
 hyper-staticfile = "0.9.2"
-ngrok = { path = "../ngrok", version = "0.11", features = ["hyper"] }
+ngrok = { path = "../ngrok", version = "0.12", features = ["hyper"] }
 tokio = { version = "1.23.0", features = ["full"] }
 watchexec = "2.3.0"

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -488,9 +488,9 @@ impl SessionBuilder {
     /// identify themselves.
     ///
     /// This will add a new entry to the `User-Agent` field in the "most significant"
-    /// (first) position. Comments must follow [RFC 7231] or a connection error may occur.
+    /// (first) position. Comments must follow [RFC 7230] or a connection error may occur.
     ///
-    /// [RFC 7231]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
+    /// [RFC 7230]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
     pub fn client_info(
         mut self,
         client_type: impl Into<String>,

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -486,6 +486,11 @@ impl SessionBuilder {
     ///
     /// This is a way for applications and library consumers of this crate
     /// identify themselves.
+    ///
+    /// This will add a new entry to the `User-Agent` field in the "most significant"
+    /// (first) position. Comments must follow [RFC 7231] or a connection error may occur.
+    ///
+    /// [RFC 7231]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
     pub fn client_info(
         mut self,
         client_type: impl Into<String>,
@@ -594,7 +599,7 @@ impl SessionBuilder {
                     sanitize_ua_string(version),
                     comments
                         .as_ref()
-                        .map_or(String::new(), |f| format!(" ({})", sanitize_ua_string(f)))
+                        .map_or(String::new(), |f| format!(" ({f})"))
                 )
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
Modeling off of [ngrok-go](https://github.com/ngrok/ngrok-go/blob/73d54eba1716e8889b7034f8ecd8071d69f8691a/session.go#L192).
Semver check fails, but this is a currently undocumented method, hopefully ok?

May want it to be `Option<Vec<String>>` to remove the `impl Into` so don't have to qualify a `None` like `None::<Vec<String>>`. Loses the flexibility, but makes the common case simpler.